### PR TITLE
feat(operator): kube-rs scaffold + CalibanTask v1alpha1 CRD (#282)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,2008 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytes"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
 name = "caliban-operator"
-version = "0.0.0"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "futures",
+ "k8s-openapi",
+ "kube",
+ "pretty_assertions",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07f808d588c10e464ea6f7d3eaed500049eff30aaac103460f61828c2d65b3eb"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e528e2d34ba8a67a1a650b86beae8ef69fc5fdb638016f386b973226590432"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "granit-parser"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50ba32164f9e098d5da618776a32afbb32270adcbe3d3d006107dae11e37c91"
+dependencies = [
+ "arraydeque",
+ "smallvec",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccfe6121cbe750cf81efa362d85c0bde7ea298ec43092d3a193baca59cdbd634"
+dependencies = [
+ "defmt",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e165e897f662d428f3cd3828a919dbe067c2d42bb1031eede74ef9d27ecdedd2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "json-patch"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "jsonpath-rust"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633a7320c4bb672863a3782e89b9094ad70285e097ff6832cddd0ec615beadfa"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "k8s-openapi"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c6922f6afe80418dd6019818af5d0d34584c371780ff09b9752370c25b4abb"
+dependencies = [
+ "base64",
+ "jiff",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "kube"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb9108095346a7096d11feeaff419c75dddcac1b2f59acb38d7bf3d13c3e146"
+dependencies = [
+ "k8s-openapi",
+ "kube-client",
+ "kube-core",
+ "kube-derive",
+ "kube-runtime",
+]
+
+[[package]]
+name = "kube-client"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f628e05bc2264c21fe10d3d675117dc9b43ea3bf4fb07262a222679757537b"
+dependencies = [
+ "base64",
+ "bytes",
+ "either",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-timeout",
+ "hyper-util",
+ "jiff",
+ "jsonpath-rust",
+ "k8s-openapi",
+ "kube-core",
+ "pem",
+ "rustls",
+ "secrecy",
+ "serde",
+ "serde-saphyr",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tracing",
+]
+
+[[package]]
+name = "kube-core"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b02f5933ba06140d58c7d6727f6c319f0962ec6a344aa5e21e475e891deaa8"
+dependencies = [
+ "derive_more",
+ "form_urlencoded",
+ "http",
+ "jiff",
+ "json-patch",
+ "k8s-openapi",
+ "schemars",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "kube-derive"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe171898707dadf1818ef94e81ef57f6beb7edf9ba87b9e814c045dad356c7aa"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "kube-runtime"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99ddec66c540c7cf29a5b41fe4a657a53687f95c346e03bdf00585b70a1bab21"
+dependencies = [
+ "ahash",
+ "async-broadcast",
+ "async-stream",
+ "backon",
+ "educe",
+ "futures",
+ "hashbrown 0.16.1",
+ "hostname",
+ "json-patch",
+ "k8s-openapi",
+ "kube-client",
+ "parking_lot",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "memchr"
+version = "2.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
+dependencies = [
+ "pest",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde-saphyr"
+version = "0.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5897b4c3faadadd35fdb6689f015641f3bc481d5adaaac56231ea15aeb243db3"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64",
+ "encoding_rs_io",
+ "getrandom 0.3.4",
+ "granit-parser",
+ "nohash-hasher",
+ "num-traits",
+ "serde",
+ "smallvec",
+ "zmij",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "2.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "base64",
+ "bitflags 2.13.0",
+ "bytes",
+ "http",
+ "http-body",
+ "mime",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,33 @@
 [package]
 name = "caliban-operator"
-version = "0.0.0"
+version = "0.1.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Kubernetes operator (kube-rs) for caliban agent workloads (scaffolding — see caliban-ai/caliban#282)"
 repository = "https://github.com/caliban-ai/caliban-operator"
 publish = false
 
+[[bin]]
+name = "caliban-operator"
+path = "src/bin/caliban-operator.rs"
+
+[[bin]]
+name = "crdgen"
+path = "src/bin/crdgen.rs"
+
 [dependencies]
+anyhow = "1.0.103"
+futures = "0.3.32"
+k8s-openapi = { version = "0.28.0", default-features = false, features = ["v1_32"] }
+kube = { version = "4.0.0", features = ["runtime", "derive", "client"] }
+schemars = "1.2.1"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.150"
+serde_yaml = "0.9.34"
+thiserror = "2.0.18"
+tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread"] }
+tracing = "0.1.44"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+
+[dev-dependencies]
+pretty_assertions = "1.4.1"

--- a/deploy/crd/calibantask.yaml
+++ b/deploy/crd/calibantask.yaml
@@ -1,0 +1,217 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: calibantasks.caliban.caliban-ai.dev
+spec:
+  group: caliban.caliban-ai.dev
+  names:
+    categories: []
+    kind: CalibanTask
+    plural: calibantasks
+    shortNames:
+    - ctask
+    singular: calibantask
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for CalibanTaskSpec via `CustomResource`
+        properties:
+          spec:
+            description: 'Desired state of a caliban task: a workspace of sources + the task to run.'
+            properties:
+              isolation:
+                description: Sandbox isolation configuration.
+                nullable: true
+                properties:
+                  runtimeClass:
+                    description: RuntimeClass (e.g. `gvisor`, `kata`).
+                    nullable: true
+                    type: string
+                  worktrees:
+                    description: Worktree isolation strategy (e.g. `per-source`).
+                    nullable: true
+                    type: string
+                type: object
+              lifecycle:
+                description: Idle/drain lifecycle policy.
+                nullable: true
+                properties:
+                  idleTimeout:
+                    description: Idle timeout before pause (e.g. `30m`).
+                    nullable: true
+                    type: string
+                  onDelete:
+                    description: 'On delete: `checkpoint` or `delete`.'
+                    nullable: true
+                    type: string
+                type: object
+              model:
+                description: Model-router configuration.
+                nullable: true
+                properties:
+                  routerConfigRef:
+                    description: Name of a ConfigMap holding the router config.
+                    nullable: true
+                    type: string
+                type: object
+              resources:
+                description: 'Resource class → a SandboxTemplate (consumed in #283).'
+                nullable: true
+                properties:
+                  class:
+                    description: Named resource class (e.g. `standard`).
+                    nullable: true
+                    type: string
+                type: object
+              state:
+                description: Persistence (gonzalo) configuration.
+                nullable: true
+                properties:
+                  gonzaloEndpoint:
+                    description: gonzalod endpoint the pod uses for shared state.
+                    nullable: true
+                    type: string
+                  mode:
+                    description: '`remote` (shared gonzalod) or `local` (in-pod).'
+                    nullable: true
+                    type: string
+                type: object
+              task:
+                description: The task itself.
+                properties:
+                  agentType:
+                    description: Agent type (e.g. `general-purpose`).
+                    nullable: true
+                    type: string
+                  prompt:
+                    description: Initial prompt.
+                    type: string
+                required:
+                - prompt
+                type: object
+              workspace:
+                description: The workspace (1..N source checkouts) the task runs over.
+                properties:
+                  services:
+                    default: []
+                    description: Optional in-pod aux services (e.g. gonzalod, prosperod) for e2e.
+                    items:
+                      type: string
+                    type: array
+                  sources:
+                    description: The guaranteed source checkouts (runtime-extensible).
+                    items:
+                      description: A single source checkout in the workspace.
+                      properties:
+                        name:
+                          description: Source identifier (matches caliband's workspace source name).
+                          type: string
+                        path:
+                          description: Absolute mount path in the pod (e.g. `/work/caliban`).
+                          type: string
+                        ref:
+                          default: main
+                          description: Git ref to check out. Defaults to `main`.
+                          type: string
+                        repo:
+                          description: Git remote to clone.
+                          type: string
+                      required:
+                      - name
+                      - path
+                      - repo
+                      type: object
+                    type: array
+                required:
+                - sources
+                type: object
+            required:
+            - task
+            - workspace
+            type: object
+          status:
+            description: Observed state of a `CalibanTask`.
+            nullable: true
+            properties:
+              calibandEndpoint:
+                description: caliband session endpoint (host:port), once the Sandbox is ready.
+                nullable: true
+                type: string
+              checkpointRef:
+                description: Latest checkpoint reference.
+                nullable: true
+                type: string
+              conditions:
+                description: Standard Kubernetes conditions.
+                items:
+                  description: A minimal Kubernetes-style condition.
+                  properties:
+                    message:
+                      description: Human-readable message.
+                      nullable: true
+                      type: string
+                    reason:
+                      description: Machine-readable reason.
+                      nullable: true
+                      type: string
+                    status:
+                      description: '`True` / `False` / `Unknown`.'
+                      type: string
+                    type:
+                      description: Condition type (e.g. `Ready`).
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              phase:
+                default: Pending
+                description: Lifecycle phase.
+                enum:
+                - Pending
+                - Provisioning
+                - Running
+                - Draining
+                - Completed
+                - Failed
+                type: string
+              sandboxRef:
+                description: The agent-sandbox Sandbox backing this task.
+                nullable: true
+                properties:
+                  name:
+                    description: Object name.
+                    type: string
+                required:
+                - name
+                type: object
+              workspace:
+                description: Observed workspace (incl. runtime-added sources).
+                nullable: true
+                properties:
+                  materialized:
+                    default: []
+                    description: Source names observed materialized in the pod.
+                    items:
+                      type: string
+                    type: array
+                type: object
+            type: object
+        required:
+        - spec
+        title: CalibanTask
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/adr/0001-kube-rs-stack-and-calibantask-crd.md
+++ b/docs/adr/0001-kube-rs-stack-and-calibantask-crd.md
@@ -31,14 +31,17 @@ Constraints and forces:
 ## Decision
 
 1. **Controller stack: kube-rs.** Depend on `kube` (features `runtime`, `derive`,
-   `client`) + `k8s-openapi` (feature `v1_31`, matching the target k3s) +
-   `schemars` (CRD schema generation) + `tokio` + `serde`/`serde_json` +
-   `serde_yaml` (CRD YAML emission) + `thiserror` + `tracing` + `futures`. Exact
-   compatible versions are resolved with `cargo add` (which honors kube's
-   `k8s-openapi` pairing) and then pinned in `Cargo.lock`; we do not hand-pick the
-   kube/k8s-openapi pair. `v1_31` is the API-surface floor; it works against k3s
-   v1.31 and newer clusters (Kubernetes API compatibility is forward-tolerant for
-   the core objects we use).
+   `client`) + `k8s-openapi` (feature `v1_32`) + `schemars` (CRD schema
+   generation) + `tokio` + `serde`/`serde_json` + `serde_yaml` (CRD YAML
+   emission) + `thiserror` + `tracing` + `futures`. Exact compatible versions are
+   resolved with `cargo add` (which honors kube's `k8s-openapi` pairing) and then
+   pinned in `Cargo.lock`; we do not hand-pick the kube/k8s-openapi pair. The
+   resolved pair is **kube 4.0 + k8s-openapi 0.28**, whose lowest offered API
+   feature is `v1_32` (there is no `v1_31` for this pairing). `v1_32` is the
+   compiled API surface; it is forward-compatible with the target **k3s v1.31**
+   apiserver for the objects we use (CRD `apiextensions.k8s.io/v1`, core objects,
+   and the agent-sandbox CRDs consumed in #283) — the Kubernetes API is tolerant
+   across a one-minor skew for these.
 
 2. **API: `caliban.caliban-ai.dev/v1alpha1`, kind `CalibanTask`, namespaced, with a
    status subresource.** Defined via `#[derive(CustomResource, …)]` on a
@@ -70,10 +73,11 @@ Constraints and forces:
   iterate the API through P2/P3 without conversion machinery.
 - **Negative:** `v1alpha1` means the CR shape can break between releases with no
   automated migration — acceptable pre-1.0, but every CR author is exposed to it.
-  Pinning `k8s-openapi` to `v1_31` ties the compiled API surface to that release;
+  Pinning `k8s-openapi` to `v1_32` ties the compiled API surface to that release;
   bumping it later is a deliberate, tested change. Committing generated YAML adds a
   keep-in-sync test that must be run when the types change (the test is the guard).
 - **Revisit if:** the API stabilizes enough to warrant `v1beta1`/`v1` + a conversion
   webhook; the target cluster's Kubernetes version moves far enough that the
-  `v1_31` `k8s-openapi` floor needs raising; or agent-sandbox's own API (consumed
-  from #283) forces a different `k8s-openapi` pairing.
+  `v1_32` `k8s-openapi` surface needs raising (or drops below the tolerated skew
+  with k3s v1.31); or agent-sandbox's own API (consumed from #283) forces a
+  different `k8s-openapi` pairing.

--- a/docs/adr/0001-kube-rs-stack-and-calibantask-crd.md
+++ b/docs/adr/0001-kube-rs-stack-and-calibantask-crd.md
@@ -1,0 +1,79 @@
+# ADR 0001 · kube-rs stack + `CalibanTask` CRD API
+
+- **Status:** accepted
+- **Date:** 2026-07-04
+- **Source:** k8s system-design spec (§"`CalibanTask` CR + workspace model", §"`caliban-operator`") in the caliban-ai docs hub · caliban [#282](https://github.com/caliban-ai/caliban/issues/282) · epic [#274](https://github.com/caliban-ai/caliban/issues/274)
+
+## Context
+
+The k8s epic (#274) needs a Kubernetes operator that reconciles a `CalibanTask`
+custom resource into a sandboxed caliband pod (via agent-sandbox). The repository
+was stood up in #277 as bare scaffolding (an empty `caliban-operator` crate, AGPL,
+Rust 1.95, a fmt/clippy/build/test CI). This ADR records the foundational,
+hard-to-change decisions that #282 commits to: the controller stack and the
+`CalibanTask` API surface (group/version/kind), which becomes a compatibility
+contract the moment a CR is applied to a cluster.
+
+Constraints and forces:
+
+- The operator is a *thin caliban-semantics layer over agent-sandbox* — it must not
+  reimplement pods/isolation/warm-pools. So the stack is a controller runtime, not
+  a pod scheduler.
+- The target homelab runs **k3s v1.31**; the CRD and the client must work there,
+  and the `k8s-openapi` version pin selects the Kubernetes API surface the operator
+  compiles against.
+- kube-rs pairs `kube` with a specific `k8s-openapi` major; the two must be chosen
+  together or the build won't resolve. Picking versions by hand is brittle.
+- The spec fixes the CR shape (`workspace.sources`, `task`, `model`, `state`,
+  `isolation`, `resources`, `lifecycle`; status `phase`/`calibandEndpoint`/
+  `sandboxRef`/`checkpointRef`/`workspace.materialized`/`conditions`).
+
+## Decision
+
+1. **Controller stack: kube-rs.** Depend on `kube` (features `runtime`, `derive`,
+   `client`) + `k8s-openapi` (feature `v1_31`, matching the target k3s) +
+   `schemars` (CRD schema generation) + `tokio` + `serde`/`serde_json` +
+   `serde_yaml` (CRD YAML emission) + `thiserror` + `tracing` + `futures`. Exact
+   compatible versions are resolved with `cargo add` (which honors kube's
+   `k8s-openapi` pairing) and then pinned in `Cargo.lock`; we do not hand-pick the
+   kube/k8s-openapi pair. `v1_31` is the API-surface floor; it works against k3s
+   v1.31 and newer clusters (Kubernetes API compatibility is forward-tolerant for
+   the core objects we use).
+
+2. **API: `caliban.caliban-ai.dev/v1alpha1`, kind `CalibanTask`, namespaced, with a
+   status subresource.** Defined via `#[derive(CustomResource, …)]` on a
+   `CalibanTaskSpec` struct mirroring the spec's fields, with a separate
+   `CalibanTaskStatus`. `v1alpha1` signals the API is unstable and may change
+   without conversion webhooks — appropriate for an MVP; graduation to `v1beta1`/`v1`
+   is a later ADR. The status subresource keeps spec (intent) and status (observed)
+   on separate update paths, as Kubernetes convention requires for controllers.
+
+3. **CRD YAML is generated, not hand-written.** A `crdgen` binary emits
+   `CalibanTask::crd()` as YAML; the generated CRD is committed (so the helm chart
+   in #284 and `kubectl apply` consumers have a stable artifact) and a test asserts
+   the committed YAML is in sync with the Rust types (regenerate-and-diff), so the
+   struct is the single source of truth.
+
+4. **#282 delivers a no-op reconcile that sets `.status.phase = Pending`.** The
+   controller skeleton watches `CalibanTask`, and its reconcile only initializes
+   status to `Pending` and requeues — it creates no Kubernetes objects. The real
+   reconcile (`CalibanTask` → agent-sandbox `Sandbox` + RBAC/NetworkPolicy) is
+   #283. The `phase` enum is the spec's lifecycle:
+   `Pending → Provisioning → Running → Draining → Completed | Failed`.
+
+## Consequences
+
+- **Positive:** the operator has a real, cluster-installable CRD and a running (if
+  inert) controller — the #282 acceptance — on a conventional, well-supported
+  Rust k8s stack. The generated-and-checked CRD makes the Rust types authoritative
+  and gives #284's chart a stable file to package. `v1alpha1` buys freedom to
+  iterate the API through P2/P3 without conversion machinery.
+- **Negative:** `v1alpha1` means the CR shape can break between releases with no
+  automated migration — acceptable pre-1.0, but every CR author is exposed to it.
+  Pinning `k8s-openapi` to `v1_31` ties the compiled API surface to that release;
+  bumping it later is a deliberate, tested change. Committing generated YAML adds a
+  keep-in-sync test that must be run when the types change (the test is the guard).
+- **Revisit if:** the API stabilizes enough to warrant `v1beta1`/`v1` + a conversion
+  webhook; the target cluster's Kubernetes version moves far enough that the
+  `v1_31` `k8s-openapi` floor needs raising; or agent-sandbox's own API (consumed
+  from #283) forces a different `k8s-openapi` pairing.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,12 @@
+# Architecture Decision Records
+
+caliban-operator keeps its architecture decisions here, in MADR-lite format (see
+[ADR 0000](0000-architecture-decision-records.md)). Each record is an append-only
+`NNNN-kebab-title.md` with **Context**, **Decision**, **Consequences**. A decision
+is changed by writing a new ADR that supersedes the old one, never by rewriting
+history.
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0000](0000-architecture-decision-records.md) | Record architecture decisions (MADR-lite under `docs/adr/`) | accepted |
+| [0001](0001-kube-rs-stack-and-calibantask-crd.md) | kube-rs stack + `CalibanTask` CRD API (`caliban.caliban-ai.dev/v1alpha1`, namespaced, status subresource; generated CRD YAML) | accepted |

--- a/docs/plans/2026-07-04-p2-crd-scaffold.md
+++ b/docs/plans/2026-07-04-p2-crd-scaffold.md
@@ -1,0 +1,649 @@
+# caliban-operator: kube-rs scaffold + CalibanTask CRD Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Scaffold the kube-rs operator and define the `CalibanTask` v1alpha1 CRD, with a generated CRD YAML and a controller skeleton whose reconcile is a no-op that sets `.status.phase = Pending`.
+
+**Architecture:** A single `caliban-operator` binary built on kube-rs. `CalibanTaskSpec`/`CalibanTaskStatus` (via `#[derive(CustomResource)]`) mirror the design spec's CR; a `crdgen` binary emits the CRD YAML (committed + kept in sync by a test); the controller watches `CalibanTask` and its reconcile only initializes status. Real reconcile (→ agent-sandbox `Sandbox`) is #283. See ADR 0001.
+
+**Tech Stack:** Rust 1.95, `kube` (runtime/derive/client), `k8s-openapi` (v1_31), `schemars`, tokio, serde, serde_yaml, thiserror, tracing, futures.
+
+## Global Constraints
+
+- **ADR 0001 governs:** API group `caliban.caliban-ai.dev`, version `v1alpha1`, kind `CalibanTask`, **namespaced**, **status subresource**. `v1alpha1` = unstable API, no conversion webhooks.
+- **CRD YAML is generated from the Rust types** (crdgen), committed, and a test asserts the committed file is in sync (regenerate-and-compare) — the Rust struct is the single source of truth.
+- **kube/k8s-openapi versions are resolved with `cargo add`** (which honors kube's k8s-openapi pairing), not hand-picked; pin whatever resolves. `k8s-openapi` feature `v1_31`.
+- **Field naming:** YAML is camelCase (k8s convention); Rust structs are snake_case with `#[serde(rename_all = "camelCase")]`. `ref` is a Rust keyword → `#[serde(rename = "ref")] r#ref` or a renamed field.
+- **#282 creates NO Kubernetes objects.** The reconcile only sets status. No Sandbox/RBAC/NetworkPolicy (that's #283).
+- CI is the standard gate: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build --workspace --all-targets`, `cargo test --workspace`. No `unwrap()`/`expect()` in non-test code.
+- The **acceptance** ("operator runs, watches, a submitted CR gets status Pending") is a *live-cluster* behavior validated at deploy/QA time; the CI-testable portion is: the types round-trip against the spec sample, the generated CRD has the right group/version/kind and is in sync, and the reconcile decision sets Pending. Do not attempt a live-cluster integration test in CI (no cluster available).
+
+---
+
+## File Structure
+
+- **Modify** `Cargo.toml` — deps + two `[[bin]]` targets (`caliban-operator`, `crdgen`); bump `version` to `0.1.0`.
+- **Create** `src/lib.rs` (replace the scaffold doc) — `pub mod crd; pub mod controller;` + re-exports.
+- **Create** `src/crd.rs` — `CalibanTask` (`CustomResource`), all spec/status sub-types, `Phase` enum.
+- **Create** `src/controller.rs` — the reconcile fn (no-op → set Pending), the error type, the `run()` that wires `kube::runtime::Controller`.
+- **Create** `src/bin/caliban-operator.rs` — main: build client, call `controller::run`.
+- **Create** `src/bin/crdgen.rs` — print `CalibanTask::crd()` as YAML.
+- **Create** `deploy/crd/calibantask.yaml` — the committed generated CRD.
+- **Test:** inline `#[cfg(test)]` in `crd.rs` (serde round-trip, crd() metadata) and `controller.rs` (reconcile decision); a sync test that regenerates the CRD and compares to the committed file.
+
+---
+
+### Task 1: kube-rs scaffold — deps + a binary that builds and connects
+
+**Files:**
+- Modify: `Cargo.toml`
+- Create: `src/lib.rs` (replace scaffold), `src/bin/caliban-operator.rs`
+
+**Interfaces:**
+- Produces: a compiling `caliban-operator` binary that (in `main`) constructs a `kube::Client` via `Client::try_default()` and logs a startup line, then exits (the controller wiring lands in Task 4). `lib.rs` declares the module structure.
+
+- [ ] **Step 1: Add deps with `cargo add`** (resolves compatible versions):
+
+```bash
+cargo add kube --features runtime,derive,client
+cargo add k8s-openapi --features v1_31 --no-default-features
+cargo add schemars
+cargo add tokio --features macros,rt-multi-thread
+cargo add serde --features derive
+cargo add serde_json
+cargo add serde_yaml
+cargo add thiserror
+cargo add tracing
+cargo add tracing-subscriber --features env-filter
+cargo add futures
+cargo add anyhow
+# dev-deps for tests:
+cargo add --dev pretty_assertions
+```
+Bump `version = "0.1.0"` and add the two bin targets:
+```toml
+[[bin]]
+name = "caliban-operator"
+path = "src/bin/caliban-operator.rs"
+
+[[bin]]
+name = "crdgen"
+path = "src/bin/crdgen.rs"
+```
+Add `[lints]` if the sibling repos use a shared lint table; otherwise rely on the CI `-D warnings` flag.
+
+- [ ] **Step 2: `src/lib.rs`** (replace the scaffold doc):
+
+```rust
+//! caliban-operator — a kube-rs operator that reconciles `CalibanTask` custom
+//! resources into sandboxed caliband pods (via agent-sandbox). See ADR 0001 and
+//! the k8s system-design spec (epic caliban-ai/caliban#274).
+
+pub mod controller;
+pub mod crd;
+
+pub use crd::{CalibanTask, CalibanTaskSpec, CalibanTaskStatus, Phase};
+```
+
+(Until Tasks 2–4 create `crd`/`controller`, this won't compile — so in Task 1 create minimal placeholder modules: `src/crd.rs` with `// filled in Task 2` and `src/controller.rs` with `// filled in Task 4`, each empty but present, and have `lib.rs` declare them. Or defer the `pub use` to Task 2. Prefer: create empty `crd.rs`/`controller.rs` now, no re-exports yet; add re-exports in Task 2/4.)
+
+- [ ] **Step 3: `src/bin/caliban-operator.rs`**
+
+```rust
+//! caliban-operator entrypoint.
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+    tracing::info!("caliban-operator starting");
+    let _client = kube::Client::try_default().await?;
+    tracing::info!("connected to the Kubernetes API");
+    // Controller wiring lands in Task 4.
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Build** — `cargo build --workspace --all-targets`. Expected: compiles. (It won't run without a cluster; that's fine — Task 1's deliverable is a compiling stack.) Run `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(operator): kube-rs scaffold — deps + compiling binary (#282)"
+```
+
+---
+
+### Task 2: `CalibanTask` CRD types (v1alpha1)
+
+**Files:**
+- Create/replace: `src/crd.rs`
+- Modify: `src/lib.rs` (add the `pub use crd::...` re-exports)
+- Test: inline `#[cfg(test)]`
+
+**Interfaces:**
+- Produces the CRD types below (exact names — Task 4 + #283 consume them). All derive `Serialize, Deserialize, Clone, Debug, JsonSchema` and use `#[serde(rename_all = "camelCase")]`.
+
+- [ ] **Step 1: Write the failing test** (round-trips the spec's sample CR + asserts `crd()` metadata)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The design spec's sample CalibanTask (camelCase YAML).
+    const SAMPLE: &str = r#"
+apiVersion: caliban.caliban-ai.dev/v1alpha1
+kind: CalibanTask
+metadata:
+  name: refactor-auth
+  namespace: team-a
+spec:
+  workspace:
+    sources:
+      - { name: caliban,  repo: "git@example:caliban",  ref: main,       path: /work/caliban }
+      - { name: prospero, repo: "git@example:prospero", ref: feat-xport, path: /work/prospero }
+    services: [ gonzalod, prosperod ]
+  task:      { prompt: "refactor the auth module", agentType: general-purpose }
+  model:     { routerConfigRef: caliban-router }
+  state:     { gonzaloEndpoint: gonzalod.storage.svc, mode: remote }
+  isolation: { runtimeClass: gvisor, worktrees: per-source }
+  resources: { class: standard }
+  lifecycle: { idleTimeout: 30m, onDelete: checkpoint }
+"#;
+
+    #[test]
+    fn sample_cr_round_trips() {
+        let task: CalibanTask = serde_yaml::from_str(SAMPLE).expect("deserialize sample");
+        assert_eq!(task.spec.workspace.sources.len(), 2);
+        assert_eq!(task.spec.workspace.sources[0].name, "caliban");
+        assert_eq!(task.spec.workspace.sources[1].r#ref, "feat-xport");
+        assert_eq!(task.spec.workspace.services, vec!["gonzalod", "prosperod"]);
+        assert_eq!(task.spec.task.prompt, "refactor the auth module");
+        assert_eq!(task.spec.task.agent_type.as_deref(), Some("general-purpose"));
+        assert_eq!(task.spec.model.as_ref().and_then(|m| m.router_config_ref.as_deref()), Some("caliban-router"));
+        assert_eq!(task.spec.isolation.as_ref().and_then(|i| i.worktrees.as_deref()), Some("per-source"));
+        // Re-serialize spec and confirm camelCase keys survive.
+        let json = serde_json::to_value(&task.spec).unwrap();
+        assert!(json["task"]["agentType"].is_string(), "camelCase key expected");
+    }
+
+    #[test]
+    fn crd_has_correct_group_version_kind() {
+        let crd = CalibanTask::crd();
+        assert_eq!(crd.spec.group, "caliban.caliban-ai.dev");
+        assert_eq!(crd.spec.names.kind, "CalibanTask");
+        assert_eq!(crd.spec.versions[0].name, "v1alpha1");
+        assert_eq!(crd.spec.scope, "Namespaced");
+        assert!(crd.spec.versions[0].subresources.as_ref().unwrap().status.is_some());
+    }
+
+    #[test]
+    fn minimal_cr_defaults() {
+        // Only required fields; optional blocks absent.
+        let yaml = r#"
+apiVersion: caliban.caliban-ai.dev/v1alpha1
+kind: CalibanTask
+metadata: { name: m, namespace: n }
+spec:
+  workspace: { sources: [ { name: only, repo: "git@x:only", path: /work/only } ] }
+  task: { prompt: hi }
+"#;
+        let task: CalibanTask = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(task.spec.workspace.sources[0].r#ref, "main"); // default ref
+        assert!(task.spec.workspace.services.is_empty());
+        assert!(task.spec.model.is_none());
+        assert!(task.spec.task.agent_type.is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails** — `cargo test -p caliban-operator crd::tests` → FAIL (types missing).
+
+- [ ] **Step 3: Implement `src/crd.rs`**
+
+```rust
+//! The `CalibanTask` custom resource (v1alpha1). Mirrors the k8s system-design
+//! spec's CR. See ADR 0001.
+
+use kube::CustomResource;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Desired state of a caliban task: a workspace of sources + the task to run.
+#[derive(CustomResource, Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[kube(
+    group = "caliban.caliban-ai.dev",
+    version = "v1alpha1",
+    kind = "CalibanTask",
+    namespaced,
+    status = "CalibanTaskStatus",
+    shortname = "ctask",
+    printcolumn = r#"{"name":"Phase","type":"string","jsonPath":".status.phase"}"#,
+    printcolumn = r#"{"name":"Age","type":"date","jsonPath":".metadata.creationTimestamp"}"#
+)]
+#[serde(rename_all = "camelCase")]
+pub struct CalibanTaskSpec {
+    /// The workspace (1..N source checkouts) the task runs over.
+    pub workspace: Workspace,
+    /// The task itself.
+    pub task: TaskSpec,
+    /// Model-router configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<ModelSpec>,
+    /// Persistence (gonzalo) configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<StateSpec>,
+    /// Sandbox isolation configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isolation: Option<IsolationSpec>,
+    /// Resource class → a SandboxTemplate (consumed in #283).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resources: Option<ResourcesSpec>,
+    /// Idle/drain lifecycle policy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lifecycle: Option<LifecycleSpec>,
+}
+
+/// A workspace: the provisioned source set + optional in-pod aux services.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Workspace {
+    /// The guaranteed source checkouts (runtime-extensible).
+    pub sources: Vec<Source>,
+    /// Optional in-pod aux services (e.g. gonzalod, prosperod) for e2e.
+    #[serde(default)]
+    pub services: Vec<String>,
+}
+
+/// A single source checkout in the workspace.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Source {
+    /// Source identifier (matches caliband's workspace source name).
+    pub name: String,
+    /// Git remote to clone.
+    pub repo: String,
+    /// Git ref to check out. Defaults to `main`.
+    #[serde(default = "default_ref")]
+    pub r#ref: String,
+    /// Absolute mount path in the pod (e.g. `/work/caliban`).
+    pub path: String,
+}
+
+fn default_ref() -> String {
+    "main".to_string()
+}
+
+/// The task to run in the workspace.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskSpec {
+    /// Initial prompt.
+    pub prompt: String,
+    /// Agent type (e.g. `general-purpose`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_type: Option<String>,
+}
+
+/// Model-router configuration.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelSpec {
+    /// Name of a ConfigMap holding the router config.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub router_config_ref: Option<String>,
+}
+
+/// Persistence (gonzalo) configuration.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct StateSpec {
+    /// gonzalod endpoint the pod uses for shared state.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gonzalo_endpoint: Option<String>,
+    /// `remote` (shared gonzalod) or `local` (in-pod).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+}
+
+/// Sandbox isolation configuration.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct IsolationSpec {
+    /// RuntimeClass (e.g. `gvisor`, `kata`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_class: Option<String>,
+    /// Worktree isolation strategy (e.g. `per-source`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktrees: Option<String>,
+}
+
+/// Resource class selecting a SandboxTemplate.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourcesSpec {
+    /// Named resource class (e.g. `standard`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub class: Option<String>,
+}
+
+/// Idle/drain lifecycle policy.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct LifecycleSpec {
+    /// Idle timeout before pause (e.g. `30m`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_timeout: Option<String>,
+    /// On delete: `checkpoint` or `delete`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_delete: Option<String>,
+}
+
+/// Observed state of a `CalibanTask`.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CalibanTaskStatus {
+    /// Lifecycle phase.
+    #[serde(default)]
+    pub phase: Phase,
+    /// caliband session endpoint (host:port), once the Sandbox is ready.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caliband_endpoint: Option<String>,
+    /// The agent-sandbox Sandbox backing this task.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox_ref: Option<NamedRef>,
+    /// Latest checkpoint reference.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checkpoint_ref: Option<String>,
+    /// Observed workspace (incl. runtime-added sources).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace: Option<WorkspaceStatus>,
+    /// Standard Kubernetes conditions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub conditions: Vec<Condition>,
+}
+
+/// A by-name reference to another object in the same namespace.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct NamedRef {
+    /// Object name.
+    pub name: String,
+}
+
+/// Observed workspace state.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceStatus {
+    /// Source names observed materialized in the pod.
+    #[serde(default)]
+    pub materialized: Vec<String>,
+}
+
+/// A minimal Kubernetes-style condition.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Condition {
+    /// Condition type (e.g. `Ready`).
+    #[serde(rename = "type")]
+    pub type_: String,
+    /// `True` / `False` / `Unknown`.
+    pub status: String,
+    /// Machine-readable reason.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Human-readable message.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+/// `CalibanTask` lifecycle phase.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq, JsonSchema)]
+pub enum Phase {
+    /// Accepted, not yet provisioning.
+    #[default]
+    Pending,
+    /// Sandbox/objects being created.
+    Provisioning,
+    /// caliband is up and attachable.
+    Running,
+    /// Draining/checkpointing before teardown.
+    Draining,
+    /// Finished successfully.
+    Completed,
+    /// Finished with an error.
+    Failed,
+}
+```
+
+Add to `lib.rs`:
+```rust
+pub use crd::{CalibanTask, CalibanTaskSpec, CalibanTaskStatus, Phase};
+```
+
+- [ ] **Step 4: Run to verify it passes** — `cargo test -p caliban-operator crd::tests`. If `serde_yaml` flow-map parsing of the `{ name: caliban, ... }` inline maps trips, adjust the SAMPLE to block style; keep the assertions. If `CalibanTask::crd()` requires the `kube` `derive` + a `.crd()` method (it does via `CustomResourceExt`), `use kube::CustomResourceExt;` in the test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(operator): CalibanTask v1alpha1 CRD types (#282)"
+```
+
+---
+
+### Task 3: `crdgen` binary + committed CRD YAML + in-sync test
+
+**Files:**
+- Create: `src/bin/crdgen.rs`, `deploy/crd/calibantask.yaml`
+- Test: inline sync test (in `crd.rs` or a `tests/` file)
+
+**Interfaces:**
+- Consumes: `CalibanTask::crd()`.
+- Produces: `crdgen` prints the CRD YAML to stdout; `deploy/crd/calibantask.yaml` is the committed output; a test regenerates and compares.
+
+- [ ] **Step 1: `src/bin/crdgen.rs`**
+
+```rust
+//! Emit the CalibanTask CRD YAML: `cargo run --bin crdgen > deploy/crd/calibantask.yaml`.
+
+use kube::CustomResourceExt;
+
+fn main() -> anyhow::Result<()> {
+    let crd = caliban_operator::crd::CalibanTask::crd();
+    print!("{}", serde_yaml::to_string(&crd)?);
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Generate + commit the CRD**
+
+```bash
+cargo run --bin crdgen > deploy/crd/calibantask.yaml
+```
+Sanity-check it starts with `apiVersion: apiextensions.k8s.io/v1` and `kind: CustomResourceDefinition`, `name: calibantasks.caliban.caliban-ai.dev`.
+
+- [ ] **Step 3: Write the in-sync test** (so the committed YAML can't drift from the types):
+
+```rust
+// in crd.rs tests (or tests/crd_sync.rs)
+#[test]
+fn committed_crd_yaml_is_in_sync() {
+    use kube::CustomResourceExt;
+    let generated = serde_yaml::to_string(&CalibanTask::crd()).unwrap();
+    let committed = include_str!("../deploy/crd/calibantask.yaml"); // adjust path
+    assert_eq!(
+        generated.trim(),
+        committed.trim(),
+        "deploy/crd/calibantask.yaml is stale — regenerate: cargo run --bin crdgen > deploy/crd/calibantask.yaml"
+    );
+}
+```
+
+(Use the correct relative path for `include_str!` from the test file's location. If `crd.rs` is at `src/crd.rs`, the path to the repo-root `deploy/…` is `../deploy/crd/calibantask.yaml`.)
+
+- [ ] **Step 4: Run** — `cargo test -p caliban-operator committed_crd_yaml_is_in_sync` → PASS. Then `cargo run --bin crdgen | diff - deploy/crd/calibantask.yaml` → no diff.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(operator): crdgen binary + committed CalibanTask CRD YAML + sync test (#282)"
+```
+
+---
+
+### Task 4: Controller skeleton — no-op reconcile sets `.status.phase = Pending`
+
+**Files:**
+- Create/replace: `src/controller.rs`
+- Modify: `src/bin/caliban-operator.rs` (call `controller::run`)
+- Test: inline reconcile-decision test
+
+**Interfaces:**
+- Consumes: `CalibanTask`, `CalibanTaskStatus`, `Phase`.
+- Produces: `pub async fn run(client: kube::Client) -> anyhow::Result<()>` wiring a `kube::runtime::Controller<CalibanTask>`; `async fn reconcile(obj, ctx) -> Result<Action, Error>` that patches status to `Pending` if unset and requeues; an `error_policy`.
+
+- [ ] **Step 1: Write the failing test** — a pure decision test for the reconcile's status choice, without a live cluster. Factor the decision into a pure fn:
+
+```rust
+// the pure decision the reconcile makes, unit-testable without a cluster
+pub(crate) fn desired_status(current: Option<&CalibanTaskStatus>) -> Option<CalibanTaskStatus> {
+    // #282: if there's no status yet (or phase is unset/default), initialize to Pending.
+    match current {
+        Some(s) if s.phase != Phase::Pending || s.caliband_endpoint.is_some() => None, // nothing to do (already progressed)
+        _ => Some(CalibanTaskStatus { phase: Phase::Pending, ..Default::default() }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn initializes_missing_status_to_pending() {
+        let d = desired_status(None).expect("should set status");
+        assert_eq!(d.phase, Phase::Pending);
+    }
+    #[test]
+    fn leaves_progressed_status_untouched() {
+        let running = CalibanTaskStatus { phase: Phase::Running, ..Default::default() };
+        assert!(desired_status(Some(&running)).is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails** — `cargo test -p caliban-operator controller::tests` → FAIL.
+
+- [ ] **Step 3: Implement `src/controller.rs`**
+
+```rust
+//! CalibanTask controller. #282: a no-op reconcile that initializes status to
+//! Pending. The real reconcile (→ agent-sandbox Sandbox + RBAC/NetworkPolicy) is
+//! caliban-ai/caliban#283.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt as _;
+use kube::api::{Patch, PatchParams};
+use kube::runtime::controller::Action;
+use kube::runtime::watcher::Config;
+use kube::runtime::Controller;
+use kube::{Api, Client, ResourceExt};
+
+use crate::crd::{CalibanTask, CalibanTaskStatus, Phase};
+
+/// Controller error.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// Kubernetes API error.
+    #[error("kube api: {0}")]
+    Kube(#[from] kube::Error),
+    /// Status serialization error.
+    #[error("serialize status: {0}")]
+    Serialize(#[from] serde_json::Error),
+}
+
+/// Shared reconcile context.
+pub struct Context {
+    /// Kubernetes client.
+    pub client: Client,
+}
+
+/// The pure status decision (unit-testable; see tests).
+pub(crate) fn desired_status(current: Option<&CalibanTaskStatus>) -> Option<CalibanTaskStatus> {
+    match current {
+        Some(s) if s.phase != Phase::Pending || s.caliband_endpoint.is_some() => None,
+        _ => Some(CalibanTaskStatus { phase: Phase::Pending, ..Default::default() }),
+    }
+}
+
+async fn reconcile(obj: Arc<CalibanTask>, ctx: Arc<Context>) -> Result<Action, Error> {
+    let ns = obj.namespace().unwrap_or_default();
+    let name = obj.name_any();
+    let api: Api<CalibanTask> = Api::namespaced(ctx.client.clone(), &ns);
+
+    if let Some(status) = desired_status(obj.status.as_ref()) {
+        let patch = serde_json::json!({ "status": status });
+        api.patch_status(&name, &PatchParams::default(), &Patch::Merge(&patch)).await?;
+        tracing::info!(%ns, %name, "initialized CalibanTask status to Pending");
+    }
+    // #282 does nothing else; requeue on a slow cadence.
+    Ok(Action::requeue(Duration::from_secs(300)))
+}
+
+fn error_policy(_obj: Arc<CalibanTask>, err: &Error, _ctx: Arc<Context>) -> Action {
+    tracing::warn!(error = %err, "reconcile error");
+    Action::requeue(Duration::from_secs(30))
+}
+
+/// Run the CalibanTask controller until shutdown.
+pub async fn run(client: Client) -> anyhow::Result<()> {
+    let tasks: Api<CalibanTask> = Api::all(client.clone());
+    let ctx = Arc::new(Context { client });
+    Controller::new(tasks, Config::default())
+        .run(reconcile, error_policy, ctx)
+        .for_each(|res| async move {
+            match res {
+                Ok((obj, _action)) => tracing::debug!(?obj, "reconciled"),
+                Err(e) => tracing::warn!(error = %e, "controller error"),
+            }
+        })
+        .await;
+    Ok(())
+}
+```
+
+Update `src/bin/caliban-operator.rs` `main` to call it:
+```rust
+    let client = kube::Client::try_default().await?;
+    tracing::info!("connected to the Kubernetes API");
+    caliban_operator::controller::run(client).await
+```
+
+- [ ] **Step 4: Run tests + full gate** — `cargo test -p caliban-operator` (the decision tests pass; note the live controller path is not exercised in CI). Then `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build --workspace --all-targets`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(operator): CalibanTask controller skeleton — reconcile sets status Pending (#282)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (#282 acceptance + ADR 0001):
+- kube-rs scaffold → Task 1. CRD `CalibanTask` v1alpha1 with all spec fields + status → Task 2. CRD YAML generation → Task 3. Controller skeleton + no-op reconcile setting Pending → Task 4. ✓
+- "CRD installs" → the committed `deploy/crd/calibantask.yaml` (Task 3) is `kubectl apply`-able; the #284 chart packages it. "operator runs + watches + CR→Pending" → Task 4 wires the Controller + sets Pending; the *live* behavior is QA-validated at deploy (no cluster in CI). ✓
+- API group/version/kind/namespaced/status subresource (ADR 0001) → asserted by `crd_has_correct_group_version_kind` (Task 2). ✓
+
+**2. Placeholder scan:** No TBD/vague steps. Task 1 notes the compatible-version resolution is via `cargo add` (exact versions can't be pinned in-plan without resolving them) — that's a grounded instruction, not a placeholder; the implementer pins what resolves.
+
+**3. Type consistency:** `CalibanTask`/`CalibanTaskSpec`/`CalibanTaskStatus`/`Phase` (Task 2) consumed by `crdgen` (Task 3) and `controller` (Task 4). `desired_status(Option<&CalibanTaskStatus>) -> Option<CalibanTaskStatus>` defined + tested + called consistently in Task 4.
+
+**Carry-overs to flag in the whole-branch review:** (a) the live "operator watches + sets Pending" acceptance is only proven at deploy/QA (no cluster in CI) — the whole-branch review should confirm the CI-testable surface is as strong as it can be and that the deploy-time check is documented; (b) `k8s-openapi` is pinned to `v1_31` — note the resolved kube/k8s-openapi versions in the PR; (c) #283 will consume `CalibanTask` + the agent-sandbox CRD (external schema — a real dependency to resolve before #283).

--- a/docs/plans/2026-07-04-p2-crd-scaffold.md
+++ b/docs/plans/2026-07-04-p2-crd-scaffold.md
@@ -6,13 +6,13 @@
 
 **Architecture:** A single `caliban-operator` binary built on kube-rs. `CalibanTaskSpec`/`CalibanTaskStatus` (via `#[derive(CustomResource)]`) mirror the design spec's CR; a `crdgen` binary emits the CRD YAML (committed + kept in sync by a test); the controller watches `CalibanTask` and its reconcile only initializes status. Real reconcile (→ agent-sandbox `Sandbox`) is #283. See ADR 0001.
 
-**Tech Stack:** Rust 1.95, `kube` (runtime/derive/client), `k8s-openapi` (v1_31), `schemars`, tokio, serde, serde_yaml, thiserror, tracing, futures.
+**Tech Stack:** Rust 1.95, `kube` (runtime/derive/client), `k8s-openapi` (v1_32), `schemars`, tokio, serde, serde_yaml, thiserror, tracing, futures.
 
 ## Global Constraints
 
 - **ADR 0001 governs:** API group `caliban.caliban-ai.dev`, version `v1alpha1`, kind `CalibanTask`, **namespaced**, **status subresource**. `v1alpha1` = unstable API, no conversion webhooks.
 - **CRD YAML is generated from the Rust types** (crdgen), committed, and a test asserts the committed file is in sync (regenerate-and-compare) — the Rust struct is the single source of truth.
-- **kube/k8s-openapi versions are resolved with `cargo add`** (which honors kube's k8s-openapi pairing), not hand-picked; pin whatever resolves. `k8s-openapi` feature `v1_31`.
+- **kube/k8s-openapi versions are resolved with `cargo add`** (which honors kube's k8s-openapi pairing), not hand-picked; pin whatever resolves. `k8s-openapi` feature `v1_32`.
 - **Field naming:** YAML is camelCase (k8s convention); Rust structs are snake_case with `#[serde(rename_all = "camelCase")]`. `ref` is a Rust keyword → `#[serde(rename = "ref")] r#ref` or a renamed field.
 - **#282 creates NO Kubernetes objects.** The reconcile only sets status. No Sandbox/RBAC/NetworkPolicy (that's #283).
 - CI is the standard gate: `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build --workspace --all-targets`, `cargo test --workspace`. No `unwrap()`/`expect()` in non-test code.
@@ -46,7 +46,7 @@
 
 ```bash
 cargo add kube --features runtime,derive,client
-cargo add k8s-openapi --features v1_31 --no-default-features
+cargo add k8s-openapi --features v1_32 --no-default-features
 cargo add schemars
 cargo add tokio --features macros,rt-multi-thread
 cargo add serde --features derive
@@ -646,4 +646,4 @@ git commit -m "feat(operator): CalibanTask controller skeleton — reconcile set
 
 **3. Type consistency:** `CalibanTask`/`CalibanTaskSpec`/`CalibanTaskStatus`/`Phase` (Task 2) consumed by `crdgen` (Task 3) and `controller` (Task 4). `desired_status(Option<&CalibanTaskStatus>) -> Option<CalibanTaskStatus>` defined + tested + called consistently in Task 4.
 
-**Carry-overs to flag in the whole-branch review:** (a) the live "operator watches + sets Pending" acceptance is only proven at deploy/QA (no cluster in CI) — the whole-branch review should confirm the CI-testable surface is as strong as it can be and that the deploy-time check is documented; (b) `k8s-openapi` is pinned to `v1_31` — note the resolved kube/k8s-openapi versions in the PR; (c) #283 will consume `CalibanTask` + the agent-sandbox CRD (external schema — a real dependency to resolve before #283).
+**Carry-overs to flag in the whole-branch review:** (a) the live "operator watches + sets Pending" acceptance is only proven at deploy/QA (no cluster in CI) — the whole-branch review should confirm the CI-testable surface is as strong as it can be and that the deploy-time check is documented; (b) `k8s-openapi` is pinned to `v1_32` — note the resolved kube/k8s-openapi versions in the PR; (c) #283 will consume `CalibanTask` + the agent-sandbox CRD (external schema — a real dependency to resolve before #283).

--- a/src/bin/caliban-operator.rs
+++ b/src/bin/caliban-operator.rs
@@ -1,0 +1,13 @@
+//! caliban-operator entrypoint.
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+    tracing::info!("caliban-operator starting");
+    let _client = kube::Client::try_default().await?;
+    tracing::info!("connected to the Kubernetes API");
+    // Controller wiring lands in Task 4.
+    Ok(())
+}

--- a/src/bin/caliban-operator.rs
+++ b/src/bin/caliban-operator.rs
@@ -6,8 +6,7 @@ async fn main() -> anyhow::Result<()> {
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
     tracing::info!("caliban-operator starting");
-    let _client = kube::Client::try_default().await?;
+    let client = kube::Client::try_default().await?;
     tracing::info!("connected to the Kubernetes API");
-    // Controller wiring lands in Task 4.
-    Ok(())
+    caliban_operator::controller::run(client).await
 }

--- a/src/bin/crdgen.rs
+++ b/src/bin/crdgen.rs
@@ -1,3 +1,9 @@
-//! CRD YAML generator entrypoint. Filled in Task 3.
+//! Emit the CalibanTask CRD YAML: `cargo run --bin crdgen > deploy/crd/calibantask.yaml`.
 
-fn main() {}
+use kube::CustomResourceExt;
+
+fn main() -> anyhow::Result<()> {
+    let crd = caliban_operator::crd::CalibanTask::crd();
+    print!("{}", serde_yaml::to_string(&crd)?);
+    Ok(())
+}

--- a/src/bin/crdgen.rs
+++ b/src/bin/crdgen.rs
@@ -1,0 +1,3 @@
+//! CRD YAML generator entrypoint. Filled in Task 3.
+
+fn main() {}

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,0 +1,1 @@
+//! filled in Task 4

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,1 +1,99 @@
-//! filled in Task 4
+//! CalibanTask controller. #282: a no-op reconcile that initializes status to
+//! Pending. The real reconcile (→ agent-sandbox Sandbox + RBAC/NetworkPolicy) is
+//! caliban-ai/caliban#283.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt as _;
+use kube::api::{Patch, PatchParams};
+use kube::runtime::controller::Action;
+use kube::runtime::watcher::Config;
+use kube::runtime::Controller;
+use kube::{Api, Client, ResourceExt};
+
+use crate::crd::{CalibanTask, CalibanTaskStatus, Phase};
+
+/// Controller error.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// Kubernetes API error.
+    #[error("kube api: {0}")]
+    Kube(#[from] kube::Error),
+    /// Status serialization error.
+    #[error("serialize status: {0}")]
+    Serialize(#[from] serde_json::Error),
+}
+
+/// Shared reconcile context.
+pub struct Context {
+    /// Kubernetes client.
+    pub client: Client,
+}
+
+/// The pure status decision (unit-testable; see tests).
+pub(crate) fn desired_status(current: Option<&CalibanTaskStatus>) -> Option<CalibanTaskStatus> {
+    match current {
+        Some(s) if s.phase != Phase::Pending || s.caliband_endpoint.is_some() => None,
+        _ => Some(CalibanTaskStatus {
+            phase: Phase::Pending,
+            ..Default::default()
+        }),
+    }
+}
+
+async fn reconcile(obj: Arc<CalibanTask>, ctx: Arc<Context>) -> Result<Action, Error> {
+    let ns = obj.namespace().unwrap_or_default();
+    let name = obj.name_any();
+    let api: Api<CalibanTask> = Api::namespaced(ctx.client.clone(), &ns);
+
+    if let Some(status) = desired_status(obj.status.as_ref()) {
+        let patch = serde_json::json!({ "status": status });
+        api.patch_status(&name, &PatchParams::default(), &Patch::Merge(&patch))
+            .await?;
+        tracing::info!(%ns, %name, "initialized CalibanTask status to Pending");
+    }
+    // #282 does nothing else; requeue on a slow cadence.
+    Ok(Action::requeue(Duration::from_secs(300)))
+}
+
+fn error_policy(_obj: Arc<CalibanTask>, err: &Error, _ctx: Arc<Context>) -> Action {
+    tracing::warn!(error = %err, "reconcile error");
+    Action::requeue(Duration::from_secs(30))
+}
+
+/// Run the CalibanTask controller until shutdown.
+pub async fn run(client: Client) -> anyhow::Result<()> {
+    let tasks: Api<CalibanTask> = Api::all(client.clone());
+    let ctx = Arc::new(Context { client });
+    Controller::new(tasks, Config::default())
+        .run(reconcile, error_policy, ctx)
+        .for_each(|res| async move {
+            match res {
+                Ok((obj, _action)) => tracing::debug!(?obj, "reconciled"),
+                Err(e) => tracing::warn!(error = %e, "controller error"),
+            }
+        })
+        .await;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::crd::{CalibanTaskStatus, Phase};
+
+    #[test]
+    fn initializes_missing_status_to_pending() {
+        let d = super::desired_status(None).expect("should set status");
+        assert_eq!(d.phase, Phase::Pending);
+    }
+
+    #[test]
+    fn leaves_progressed_status_untouched() {
+        let running = CalibanTaskStatus {
+            phase: Phase::Running,
+            ..Default::default()
+        };
+        assert!(super::desired_status(Some(&running)).is_none());
+    }
+}

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -34,11 +34,13 @@ pub struct Context {
 /// The pure status decision (unit-testable; see tests).
 pub(crate) fn desired_status(current: Option<&CalibanTaskStatus>) -> Option<CalibanTaskStatus> {
     match current {
-        Some(s) if s.phase != Phase::Pending || s.caliband_endpoint.is_some() => None,
-        _ => Some(CalibanTaskStatus {
+        // No status yet: initialize to Pending (#282). Once any status exists —
+        // Pending or progressed by #283's reconcile — leave it untouched.
+        None => Some(CalibanTaskStatus {
             phase: Phase::Pending,
             ..Default::default()
         }),
+        Some(_) => None,
     }
 }
 
@@ -83,17 +85,36 @@ mod tests {
     use crate::crd::{CalibanTaskStatus, Phase};
 
     #[test]
-    fn initializes_missing_status_to_pending() {
+    fn initializes_absent_status_to_pending() {
         let d = super::desired_status(None).expect("should set status");
         assert_eq!(d.phase, Phase::Pending);
     }
 
     #[test]
-    fn leaves_progressed_status_untouched() {
+    fn leaves_running_status_untouched() {
         let running = CalibanTaskStatus {
             phase: Phase::Running,
             ..Default::default()
         };
         assert!(super::desired_status(Some(&running)).is_none());
+    }
+
+    #[test]
+    fn does_not_repatch_already_pending_status() {
+        let pending = CalibanTaskStatus {
+            phase: Phase::Pending,
+            ..Default::default()
+        };
+        assert!(super::desired_status(Some(&pending)).is_none());
+    }
+
+    #[test]
+    fn leaves_pending_with_endpoint_untouched() {
+        let pending_with_endpoint = CalibanTaskStatus {
+            phase: Phase::Pending,
+            caliband_endpoint: Some("10.0.0.1:9000".to_string()),
+            ..Default::default()
+        };
+        assert!(super::desired_status(Some(&pending_with_endpoint)).is_none());
     }
 }

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -1,0 +1,1 @@
+//! filled in Task 2

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -287,6 +287,17 @@ spec:
     }
 
     #[test]
+    fn committed_crd_yaml_is_in_sync() {
+        let generated = serde_yaml::to_string(&CalibanTask::crd()).unwrap();
+        let committed = include_str!("../deploy/crd/calibantask.yaml");
+        assert_eq!(
+            generated.trim(),
+            committed.trim(),
+            "deploy/crd/calibantask.yaml is stale — regenerate: cargo run --bin crdgen > deploy/crd/calibantask.yaml"
+        );
+    }
+
+    #[test]
     fn minimal_cr_defaults() {
         // Only required fields; optional blocks absent.
         let yaml = r#"

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -1,1 +1,306 @@
-//! filled in Task 2
+//! The `CalibanTask` custom resource (v1alpha1). Mirrors the k8s system-design
+//! spec's CR. See ADR 0001.
+
+use kube::CustomResource;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Desired state of a caliban task: a workspace of sources + the task to run.
+#[derive(CustomResource, Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[kube(
+    group = "caliban.caliban-ai.dev",
+    version = "v1alpha1",
+    kind = "CalibanTask",
+    namespaced,
+    status = "CalibanTaskStatus",
+    shortname = "ctask",
+    printcolumn = r#"{"name":"Phase","type":"string","jsonPath":".status.phase"}"#,
+    printcolumn = r#"{"name":"Age","type":"date","jsonPath":".metadata.creationTimestamp"}"#
+)]
+#[serde(rename_all = "camelCase")]
+pub struct CalibanTaskSpec {
+    /// The workspace (1..N source checkouts) the task runs over.
+    pub workspace: Workspace,
+    /// The task itself.
+    pub task: TaskSpec,
+    /// Model-router configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<ModelSpec>,
+    /// Persistence (gonzalo) configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<StateSpec>,
+    /// Sandbox isolation configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isolation: Option<IsolationSpec>,
+    /// Resource class → a SandboxTemplate (consumed in #283).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resources: Option<ResourcesSpec>,
+    /// Idle/drain lifecycle policy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lifecycle: Option<LifecycleSpec>,
+}
+
+/// A workspace: the provisioned source set + optional in-pod aux services.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Workspace {
+    /// The guaranteed source checkouts (runtime-extensible).
+    pub sources: Vec<Source>,
+    /// Optional in-pod aux services (e.g. gonzalod, prosperod) for e2e.
+    #[serde(default)]
+    pub services: Vec<String>,
+}
+
+/// A single source checkout in the workspace.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Source {
+    /// Source identifier (matches caliband's workspace source name).
+    pub name: String,
+    /// Git remote to clone.
+    pub repo: String,
+    /// Git ref to check out. Defaults to `main`.
+    #[serde(default = "default_ref")]
+    pub r#ref: String,
+    /// Absolute mount path in the pod (e.g. `/work/caliban`).
+    pub path: String,
+}
+
+fn default_ref() -> String {
+    "main".to_string()
+}
+
+/// The task to run in the workspace.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskSpec {
+    /// Initial prompt.
+    pub prompt: String,
+    /// Agent type (e.g. `general-purpose`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_type: Option<String>,
+}
+
+/// Model-router configuration.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelSpec {
+    /// Name of a ConfigMap holding the router config.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub router_config_ref: Option<String>,
+}
+
+/// Persistence (gonzalo) configuration.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct StateSpec {
+    /// gonzalod endpoint the pod uses for shared state.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gonzalo_endpoint: Option<String>,
+    /// `remote` (shared gonzalod) or `local` (in-pod).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<String>,
+}
+
+/// Sandbox isolation configuration.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct IsolationSpec {
+    /// RuntimeClass (e.g. `gvisor`, `kata`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_class: Option<String>,
+    /// Worktree isolation strategy (e.g. `per-source`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub worktrees: Option<String>,
+}
+
+/// Resource class selecting a SandboxTemplate.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourcesSpec {
+    /// Named resource class (e.g. `standard`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub class: Option<String>,
+}
+
+/// Idle/drain lifecycle policy.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct LifecycleSpec {
+    /// Idle timeout before pause (e.g. `30m`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_timeout: Option<String>,
+    /// On delete: `checkpoint` or `delete`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_delete: Option<String>,
+}
+
+/// Observed state of a `CalibanTask`.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CalibanTaskStatus {
+    /// Lifecycle phase.
+    #[serde(default)]
+    pub phase: Phase,
+    /// caliband session endpoint (host:port), once the Sandbox is ready.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub caliband_endpoint: Option<String>,
+    /// The agent-sandbox Sandbox backing this task.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox_ref: Option<NamedRef>,
+    /// Latest checkpoint reference.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checkpoint_ref: Option<String>,
+    /// Observed workspace (incl. runtime-added sources).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace: Option<WorkspaceStatus>,
+    /// Standard Kubernetes conditions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub conditions: Vec<Condition>,
+}
+
+/// A by-name reference to another object in the same namespace.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct NamedRef {
+    /// Object name.
+    pub name: String,
+}
+
+/// Observed workspace state.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceStatus {
+    /// Source names observed materialized in the pod.
+    #[serde(default)]
+    pub materialized: Vec<String>,
+}
+
+/// A minimal Kubernetes-style condition.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Condition {
+    /// Condition type (e.g. `Ready`).
+    #[serde(rename = "type")]
+    pub type_: String,
+    /// `True` / `False` / `Unknown`.
+    pub status: String,
+    /// Machine-readable reason.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Human-readable message.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+/// `CalibanTask` lifecycle phase.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq, JsonSchema)]
+pub enum Phase {
+    /// Accepted, not yet provisioning.
+    #[default]
+    Pending,
+    /// Sandbox/objects being created.
+    Provisioning,
+    /// caliband is up and attachable.
+    Running,
+    /// Draining/checkpointing before teardown.
+    Draining,
+    /// Finished successfully.
+    Completed,
+    /// Finished with an error.
+    Failed,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kube::CustomResourceExt;
+
+    // The design spec's sample CalibanTask (camelCase YAML).
+    const SAMPLE: &str = r#"
+apiVersion: caliban.caliban-ai.dev/v1alpha1
+kind: CalibanTask
+metadata:
+  name: refactor-auth
+  namespace: team-a
+spec:
+  workspace:
+    sources:
+      - { name: caliban,  repo: "git@example:caliban",  ref: main,       path: /work/caliban }
+      - { name: prospero, repo: "git@example:prospero", ref: feat-xport, path: /work/prospero }
+    services: [ gonzalod, prosperod ]
+  task:      { prompt: "refactor the auth module", agentType: general-purpose }
+  model:     { routerConfigRef: caliban-router }
+  state:     { gonzaloEndpoint: gonzalod.storage.svc, mode: remote }
+  isolation: { runtimeClass: gvisor, worktrees: per-source }
+  resources: { class: standard }
+  lifecycle: { idleTimeout: 30m, onDelete: checkpoint }
+"#;
+
+    #[test]
+    fn sample_cr_round_trips() {
+        let task: CalibanTask = serde_yaml::from_str(SAMPLE).expect("deserialize sample");
+        assert_eq!(task.spec.workspace.sources.len(), 2);
+        assert_eq!(task.spec.workspace.sources[0].name, "caliban");
+        assert_eq!(task.spec.workspace.sources[1].r#ref, "feat-xport");
+        assert_eq!(task.spec.workspace.services, vec!["gonzalod", "prosperod"]);
+        assert_eq!(task.spec.task.prompt, "refactor the auth module");
+        assert_eq!(
+            task.spec.task.agent_type.as_deref(),
+            Some("general-purpose")
+        );
+        assert_eq!(
+            task.spec
+                .model
+                .as_ref()
+                .and_then(|m| m.router_config_ref.as_deref()),
+            Some("caliban-router")
+        );
+        assert_eq!(
+            task.spec
+                .isolation
+                .as_ref()
+                .and_then(|i| i.worktrees.as_deref()),
+            Some("per-source")
+        );
+        // Re-serialize spec and confirm camelCase keys survive.
+        let json = serde_json::to_value(&task.spec).unwrap();
+        assert!(
+            json["task"]["agentType"].is_string(),
+            "camelCase key expected"
+        );
+    }
+
+    #[test]
+    fn crd_has_correct_group_version_kind() {
+        let crd = CalibanTask::crd();
+        assert_eq!(crd.spec.group, "caliban.caliban-ai.dev");
+        assert_eq!(crd.spec.names.kind, "CalibanTask");
+        assert_eq!(crd.spec.versions[0].name, "v1alpha1");
+        assert_eq!(crd.spec.scope, "Namespaced");
+        assert!(crd.spec.versions[0]
+            .subresources
+            .as_ref()
+            .unwrap()
+            .status
+            .is_some());
+    }
+
+    #[test]
+    fn minimal_cr_defaults() {
+        // Only required fields; optional blocks absent.
+        let yaml = r#"
+apiVersion: caliban.caliban-ai.dev/v1alpha1
+kind: CalibanTask
+metadata: { name: m, namespace: n }
+spec:
+  workspace: { sources: [ { name: only, repo: "git@x:only", path: /work/only } ] }
+  task: { prompt: hi }
+"#;
+        let task: CalibanTask = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(task.spec.workspace.sources[0].r#ref, "main"); // default ref
+        assert!(task.spec.workspace.services.is_empty());
+        assert!(task.spec.model.is_none());
+        assert!(task.spec.task.agent_type.is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
-//! caliban-operator — Kubernetes operator (kube-rs) for caliban agent workloads.
-//!
-//! Repository scaffolding only. The `CalibanTask` CRD and the reconcile loop land
-//! in caliban-ai/caliban#282 and #283. See the k8s system design spec and the
-//! umbrella epic caliban-ai/caliban#274.
+//! caliban-operator — a kube-rs operator that reconciles `CalibanTask` custom
+//! resources into sandboxed caliband pods (via agent-sandbox). See ADR 0001 and
+//! the k8s system-design spec (epic caliban-ai/caliban#274).
+
+pub mod controller;
+pub mod crd;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,5 @@
 
 pub mod controller;
 pub mod crd;
+
+pub use crd::{CalibanTask, CalibanTaskSpec, CalibanTaskStatus, Phase};


### PR DESCRIPTION
## What

Stands up the `caliban-operator` on kube-rs and defines the **`CalibanTask` v1alpha1 CRD** — the first real ticket (#282) of P2 (operator MVP) in the k8s epic (#274). The operator reconciles `CalibanTask` CRs into sandboxed caliband pods; this PR delivers the scaffold + CRD + a controller skeleton (no-op reconcile → status `Pending`). The real reconcile (→ agent-sandbox `Sandbox`) is #283.

Implements **ADR 0001** (operator foundation).

## How (4 TDD tasks, subagent-driven)

1. **kube-rs scaffold** — resolved stack **kube 4.0.0 + k8s-openapi 0.28.0 (feature `v1_32`) + schemars 1.2.1** (via `cargo add`; `v1_31` isn't offered by this pairing — `v1_32` is forward-compatible with the target k3s v1.31 for the CRD/core objects used). A compiling binary that builds a `kube::Client`.
2. **`CalibanTask` CRD types** — `caliban.caliban-ai.dev/v1alpha1`, namespaced, status subresource; full spec (`workspace.sources`, `task`, `model`, `state`, `isolation`, `resources`, `lifecycle`) + status (`phase`/`calibandEndpoint`/`sandboxRef`/`checkpointRef`/`workspace.materialized`/`conditions`). camelCase wire; round-trips the design-spec sample.
3. **crdgen + committed CRD YAML** — `crdgen` emits `CalibanTask::crd()`; `deploy/crd/calibantask.yaml` is committed and a sync test guards it against drift (verified to catch drift).
4. **Controller skeleton** — `Controller<CalibanTask>` + a no-op reconcile that **init-once** sets `.status.phase = Pending` (creates zero Kubernetes objects); reconcile decision factored into a pure `desired_status` and unit-tested.

## Acceptance (#282)

- ✅ CRD installs — `deploy/crd/calibantask.yaml` is a valid, complete `apiextensions.k8s.io/v1` CRD (namespaced, status subresource, populated `openAPIV3Schema`)
- ✅ operator runs + watches `CalibanTask`; a submitted CR → status `Pending` — **the *live* watch/reconcile is deploy/QA-validated** (no cluster in CI); the CI-testable surface (types round-trip, CRD GVK/subresource, sync test, reconcile decision) is green.

## Review & scope

Whole-branch review (opus): **merge with fixes** — no Critical/Important; two trivial Minors fixed (init-once reconcile + a guard test case). The v1_32/v1.31 skew is genuinely safe here (only CRD apiextensions/v1 + the CR are touched). **Deploy dependency for #284:** the operator does a cluster-wide watch, so #284's chart must ship the operator ServiceAccount + a ClusterRole granting `calibantasks` get/list/watch + `calibantasks/status` patch — that's what makes the live acceptance pass at deploy. Deferred hardening (CRD `minItems`/`minLength`, graceful shutdown, serde_yaml migration) filed as caliban-operator#2.

Gate: fmt/clippy(`-D warnings`)/build/test all green (8 tests).

Closes caliban-ai/caliban#282. Part of caliban-ai/caliban#274.