### PR TITLE
feat(operator): reconcile CalibanTask → Sandbox + token-less SA + default-deny NetworkPolicy (#283)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,6 +803,7 @@ checksum = "d9c6922f6afe80418dd6019818af5d0d34584c371780ff09b9752370c25b4abb"
 dependencies = [
  "base64",
  "jiff",
+ "schemars",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/bin/crdgen.rs"
 [dependencies]
 anyhow = "1.0.103"
 futures = "0.3.32"
-k8s-openapi = { version = "0.28.0", default-features = false, features = ["v1_32"] }
+k8s-openapi = { version = "0.28.0", default-features = false, features = ["v1_32", "schemars"] }
 kube = { version = "4.0.0", features = ["runtime", "derive", "client"] }
 schemars = "1.2.1"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/docs/adr/0002-reconcile-calibantask-to-sandbox.md
+++ b/docs/adr/0002-reconcile-calibantask-to-sandbox.md
@@ -1,0 +1,124 @@
+# ADR 0002 · Reconcile `CalibanTask` → agent-sandbox `Sandbox` (+ per-task SA & NetworkPolicy)
+
+- **Status:** accepted
+- **Date:** 2026-07-04
+- **Source:** k8s system-design spec (§"`caliban-operator`", §"agent-sandbox integration") in the caliban-ai docs hub · caliban [#283](https://github.com/caliban-ai/caliban/issues/283) · epic [#274](https://github.com/caliban-ai/caliban/issues/274) · builds on [ADR 0001](0001-kube-rs-stack-and-calibantask-crd.md)
+
+## Context
+
+[ADR 0001](0001-kube-rs-stack-and-calibantask-crd.md) fixed the controller stack
+(kube 4.0 / k8s-openapi 0.28 / `v1_32`) and the `CalibanTask` API. #282 shipped a
+placeholder reconcile that only initialized `.status.phase = Pending`. #283 makes
+the reconcile real: turn a `CalibanTask` into a running, sandboxed caliband pod
+reachable at a stable DNS, with per-task RBAC and network isolation, and drive
+`.status` from the backing Sandbox.
+
+The spec is explicit that the operator is a *thin caliban-semantics layer over
+agent-sandbox* — it must not reimplement pods/isolation. So the reconcile composes
+existing objects rather than managing pods directly.
+
+Forces:
+
+- **agent-sandbox owns the `Sandbox` CRD** (`agents.x-k8s.io/v1beta1`). We consume
+  it — we must not generate, install, or drift-guard its schema. Verified v0.5.0
+  `SandboxSpec` = `{ podTemplate{metadata,spec: core.PodSpec} (required), service
+  bool, operatingMode enum(Running|Suspended)=Running, shutdownPolicy
+  enum(Delete|Retain)=Retain, shutdownTime, volumeClaimTemplates []core.PVC }`;
+  `SandboxStatus.serviceFQDN` is the pod's stable DNS.
+- **Reconcile must be idempotent and self-healing** — re-running on the same
+  `CalibanTask` must converge, not duplicate, and children must be garbage-collected
+  when the `CalibanTask` is deleted.
+- **Cluster-agnostic** (the eventual charts are public): no home-cluster
+  identifiers baked into generated objects.
+- **k3s v1.31 target vs `v1_32` compile surface** (ADR 0001): stick to long-stable
+  `PodSpec`/`NetworkPolicy` fields.
+- The caliband pod needs **zero** Kubernetes API access; its identity exists only
+  to be a NetworkPolicy/PodSecurity subject.
+
+## Decision
+
+1. **Consume `Sandbox` as a foreign typed resource.** Hand-author a minimal Rust
+   `Sandbox` via `#[derive(CustomResource)]` pointed at
+   `group = "agents.x-k8s.io", version = "v1beta1", kind = "Sandbox", namespaced,
+   status = "SandboxStatus"`, declaring only the fields we set or read
+   (`podTemplate`, `service`, `operatingMode`, `shutdownPolicy`, `shutdownTime`,
+   `volumeClaimTemplates`; status `serviceFQDN`, `conditions`). `podTemplate`
+   reuses `k8s_openapi` `PodTemplateSpec`; `volumeClaimTemplates` reuses
+   `PersistentVolumeClaim`. We **never** call `Sandbox::crd()`, emit its YAML, or
+   add it to the drift-sync test — agent-sandbox installs its own CRD. Extra
+   `SandboxSpec` fields we omit are pruned by the API server's structural schema;
+   this is a read/write view, not the schema of record.
+
+2. **Reconcile = pure builders + a thin apply loop.** The mapping
+   `CalibanTask → {Sandbox, ServiceAccount, NetworkPolicy}` and the status
+   derivation are **pure functions** (`build_sandbox`, `build_service_account`,
+   `build_network_policy`, `derive_status`), unit-tested with no cluster. The async
+   reconcile only: server-side-applies each child, reads back the Sandbox, and
+   patches `CalibanTask.status`.
+
+3. **Idempotency via server-side apply + owner references.** Children are applied
+   with `Patch::Apply` under field manager `caliban-operator` (force), so
+   re-reconciles converge on one object. Every child carries a controller
+   `OwnerReference` to its `CalibanTask`, so deleting the task cascades. Child names
+   are deterministic: `<task>-sbx` (Sandbox), `<task>-sa` (ServiceAccount),
+   `<task>-netpol` (NetworkPolicy).
+
+4. **Least-privilege RBAC = a dedicated, token-less ServiceAccount with no bound
+   Role.** The caliband pod is given its own per-task `ServiceAccount` with
+   `automountServiceAccountToken: false`, referenced from the podTemplate. Because
+   no `Role`/`RoleBinding` is created, the pod holds **zero** API permissions —
+   strictly the least privilege. An empty Role would be noise; the token-less SA
+   *is* the RBAC posture. (The operator's *own* cluster RBAC — the right to create
+   Sandboxes/SAs/NetworkPolicies — is deploy-time chart concern #284, not this
+   reconcile.)
+
+5. **NetworkPolicy: default-deny with the minimal working allowances.** The
+   per-task `NetworkPolicy` selects the Sandbox's pod labels and sets
+   `policyTypes: [Ingress, Egress]` with: deny-all by default, **allow DNS egress**
+   (UDP/TCP 53), **allow general egress** (git clone + provider APIs; MVP allows
+   egress to all non-cluster destinations), and **allow ingress on the caliband
+   port** (8443) from the task's namespace. The spec's finer rules
+   (prospero→caliband, pod→gonzalo) require cross-namespace identity the CR does
+   not carry generically at MVP; they are parameterized in a later iteration. The
+   MVP ships a real, cluster-agnostic default-deny posture (selectors are the
+   pod's own labels — no home-cluster identifiers).
+
+6. **Status is derived from the Sandbox, not initialized-and-frozen.** This
+   evolves #282's init-once no-op: `derive_status(task, sandbox)` returns
+   `Provisioning` once the Sandbox is applied but has no `serviceFQDN` yet,
+   `Running` once `serviceFQDN` is populated, and sets
+   `calibandEndpoint = "<serviceFQDN>:8443"` and `sandboxRef` accordingly. `Pending`
+   remains the pre-provision default (a `CalibanTask` observed before its first
+   successful apply). The status patch is skipped when the derived status equals
+   the observed one (no-op churn avoidance, same discipline as #282).
+
+7. **Explicit deferrals (out of #283 scope, tracked upstream):** the caliban-aware
+   drain finalizer (needs caliband's checkpoint gRPC — deferred with the transport
+   #314), idle→pause/resume mapping, `SandboxTemplate`/`SandboxWarmPool` (Phase 4),
+   and full `Secret`/`ConfigMap` credential projection. #283 projects only what the
+   acceptance path needs: the workspace PVC, the caliband image + runtimeClass, and
+   the gonzalo endpoint / model-router refs as env, so the pod comes up reachable.
+
+## Consequences
+
+- **A `CalibanTask` now materializes real cluster objects.** Applying one yields a
+  Sandbox (→ caliband pod on the configured RuntimeClass, workspace PVC, stable
+  DNS), a token-less SA, and a default-deny NetworkPolicy; `.status` reports
+  `Provisioning → Running` with `calibandEndpoint`. This satisfies #283's
+  acceptance and unblocks prospero's `K8sFleet` (#64) reading the endpoint.
+- **agent-sandbox must be installed in the cluster** for the applies to succeed
+  (its `Sandbox` CRD must exist). This is the cluster prerequisite the umbrella
+  chart bundles by default (helm-charts#6); without it the operator's Sandbox apply
+  fails and the task stays `Provisioning` — an honest, retried error, not a crash.
+- **The operator needs cluster RBAC to create these children** — it can create
+  `sandboxes.agents.x-k8s.io`, `serviceaccounts`, and
+  `networkpolicies.networking.k8s.io`, and patch `calibantasks/status`. That
+  ClusterRole ships with the operator chart (#284); this ADR fixes the exact verb
+  set that chart must grant.
+- **Deferring the drain finalizer** means a deleted `CalibanTask` tears down its
+  Sandbox immediately (owner-ref GC) without checkpointing in-flight agents. This
+  is acceptable for the MVP and revisited when caliband checkpoint gRPC lands.
+- **The foreign `Sandbox` view can rot** if agent-sandbox changes its v1beta1
+  schema. We pin the consumed version (`v1beta1`) and cover the fields we use with
+  round-trip tests against the published CRD's shape; a breaking upstream change
+  surfaces as a deserialize/apply failure, caught in integration.

--- a/docs/adr/0002-reconcile-calibantask-to-sandbox.md
+++ b/docs/adr/0002-reconcile-calibantask-to-sandbox.md
@@ -75,9 +75,12 @@ Forces:
 5. **NetworkPolicy: default-deny with the minimal working allowances.** The
    per-task `NetworkPolicy` selects the Sandbox's pod labels and sets
    `policyTypes: [Ingress, Egress]` with: deny-all by default, **allow DNS egress**
-   (UDP/TCP 53), **allow general egress** (git clone + provider APIs; MVP allows
-   egress to all non-cluster destinations), and **allow ingress on the caliband
-   port** (8443) from the task's namespace. The spec's finer rules
+   (UDP/TCP 53), **allow general egress** (git clone + provider APIs; the empty-`to`
+   rule allows egress to all destinations at MVP, in-cluster included — restricting
+   it to non-cluster CIDRs is deferred because it would require an
+   environment-specific cluster CIDR, a home-cluster identifier we don't bake in),
+   and **allow ingress on the caliband port** (8443) from the task's namespace. The
+   spec's finer rules
    (prospero→caliband, pod→gonzalo) require cross-namespace identity the CR does
    not carry generically at MVP; they are parameterized in a later iteration. The
    MVP ships a real, cluster-agnostic default-deny posture (selectors are the

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,3 +10,4 @@ history.
 |-----|-------|--------|
 | [0000](0000-architecture-decision-records.md) | Record architecture decisions (MADR-lite under `docs/adr/`) | accepted |
 | [0001](0001-kube-rs-stack-and-calibantask-crd.md) | kube-rs stack + `CalibanTask` CRD API (`caliban.caliban-ai.dev/v1alpha1`, namespaced, status subresource; generated CRD YAML) | accepted |
+| [0002](0002-reconcile-calibantask-to-sandbox.md) | Reconcile `CalibanTask` → agent-sandbox `Sandbox` (+ per-task token-less SA & default-deny NetworkPolicy; foreign `Sandbox` type; SSA + owner refs; status from `serviceFQDN`) | accepted |

--- a/docs/plans/2026-07-04-p2-reconcile-sandbox.md
+++ b/docs/plans/2026-07-04-p2-reconcile-sandbox.md
@@ -1,0 +1,842 @@
+# CalibanTask → Sandbox Reconcile Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the operator's reconcile turn a `CalibanTask` into a running, sandboxed caliband pod reachable at a stable DNS, with a per-task token-less ServiceAccount and a default-deny NetworkPolicy, and drive `.status` (phase + `calibandEndpoint`) from the backing agent-sandbox `Sandbox`.
+
+**Architecture:** The reconcile is **pure builders + a thin apply loop** (ADR 0002). Pure functions map `CalibanTask → {Sandbox, ServiceAccount, NetworkPolicy}` and derive status; the async reconcile server-side-applies each child (owner-referenced for GC), reads the Sandbox back, and patches `CalibanTask.status`. The `Sandbox` (`agents.x-k8s.io/v1beta1`) is consumed as a hand-authored foreign typed resource — we never emit its CRD.
+
+**Tech Stack:** Rust, kube 4.0 (`runtime`/`derive`/`client`), k8s-openapi 0.28 (`v1_32` + **`schemars`** feature), schemars 1.2, serde, tokio.
+
+## Global Constraints
+
+- **Do not reimplement pods/isolation** — compose agent-sandbox's `Sandbox`; the operator is a thin caliban-semantics layer (ADR 0002 §Decision 1).
+- **Cluster-agnostic** — no home-cluster identifiers (hostnames, domains, IPs, storage classes, ingress classes, node selectors) in any generated object. Environment-specifics come from operator config with neutral defaults (`storageClass` omitted → cluster default).
+- **Idempotent reconcile** — server-side apply (`Patch::Apply`, field manager `"caliban-operator"`, `.force()`) + a controller `OwnerReference` on every child. Deterministic child names: `<task>-sbx`, `<task>-sa`, `<task>-netpol`.
+- **Least-privilege pod identity** — per-task `ServiceAccount` with `automountServiceAccountToken: false` and **no** bound Role (zero API rights). Referenced from the podTemplate.
+- **caliband network contract** — the pod listens TCP+TLS on port **8443**; the Sandbox sets `service: true` so agent-sandbox provisions the Service whose `serviceFQDN` is the session endpoint. `calibandEndpoint = "<serviceFQDN>:8443"`.
+- **Do not emit or drift-guard the `Sandbox` CRD** — agent-sandbox owns it. `crdgen` and the committed `deploy/crd/*.yaml` remain CalibanTask-only.
+- Pure builders/derivation are **unit-tested with no cluster**. The async apply glue is thin.
+- Preserve existing behavior: `desired_status`'s no-op-when-unchanged discipline (#282) carries into `derive_status`.
+
+---
+
+### Task 1: Foreign `Sandbox` resource type (`agents.x-k8s.io/v1beta1`)
+
+**Files:**
+- Modify: `Cargo.toml` (add `schemars` to k8s-openapi features)
+- Create: `src/sandbox.rs`
+- Modify: `src/lib.rs` (add `pub mod sandbox;`)
+
+**Interfaces:**
+- Produces: `Sandbox` (kube `CustomResource`-derived root), `SandboxSpec`, `SandboxStatus`. Used by Tasks 4/5/6.
+
+**Context:** agent-sandbox's verified v1beta1 `SandboxSpec` = `{ podTemplate{metadata,spec} (required), service bool, operatingMode enum(Running|Suspended), shutdownPolicy enum(Delete|Retain), shutdownTime string, volumeClaimTemplates []core.PVC }`; `SandboxStatus` = `{ serviceFQDN, service, podIPs, nodeName, conditions }`. We declare only the fields we set (`podTemplate`, `service`, `operatingMode`, `volumeClaimTemplates`) or read (`serviceFQDN`, `conditions`); omitted fields are pruned by the API server. `podTemplate` reuses `k8s_openapi::api::core::v1::PodTemplateSpec`; `volumeClaimTemplates` reuses `PersistentVolumeClaim`. Deriving `CustomResource` requires `JsonSchema`, which is why k8s-openapi needs its `schemars` feature (uses schemars `1` — matches our 1.2). We never call `Sandbox::crd()`.
+
+- [ ] **Step 1: Enable k8s-openapi schemars feature**
+
+In `Cargo.toml`, change:
+```toml
+k8s-openapi = { version = "0.28.0", default-features = false, features = ["v1_32", "schemars"] }
+```
+
+- [ ] **Step 2: Write `src/sandbox.rs`**
+
+```rust
+//! A minimal foreign view of agent-sandbox's `Sandbox` CRD
+//! (`agents.x-k8s.io/v1beta1`). We consume it — we declare only the fields the
+//! operator sets or reads; the API server prunes the rest. We never emit this
+//! CRD (agent-sandbox owns it), so `Sandbox::crd()` is intentionally unused. See
+//! ADR 0002.
+
+use k8s_openapi::api::core::v1::{PersistentVolumeClaim, PodTemplateSpec};
+use kube::CustomResource;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Desired state of an agent-sandbox `Sandbox` (subset the operator manages).
+#[derive(CustomResource, Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[kube(
+    group = "agents.x-k8s.io",
+    version = "v1beta1",
+    kind = "Sandbox",
+    namespaced,
+    status = "SandboxStatus"
+)]
+#[serde(rename_all = "camelCase")]
+pub struct SandboxSpec {
+    /// Pod template for the sandbox's single pod.
+    pub pod_template: PodTemplateSpec,
+    /// Provision a headless Service (→ stable `serviceFQDN`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service: Option<bool>,
+    /// `Running` or `Suspended`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operating_mode: Option<String>,
+    /// PVCs materialized for the sandbox (persist across restarts).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub volume_claim_templates: Option<Vec<PersistentVolumeClaim>>,
+}
+
+/// Observed state of a `Sandbox` (subset the operator reads).
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SandboxStatus {
+    /// Stable in-cluster DNS name for the sandbox's Service.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_fqdn: Option<String>,
+}
+```
+
+- [ ] **Step 3: Register the module** — add `pub mod sandbox;` to `src/lib.rs`.
+
+- [ ] **Step 4: Write the round-trip test** (in `src/sandbox.rs`)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sandbox_serializes_with_group_version_kind() {
+        let sb = Sandbox::new(
+            "demo-sbx",
+            SandboxSpec {
+                pod_template: PodTemplateSpec::default(),
+                service: Some(true),
+                operating_mode: Some("Running".to_string()),
+                volume_claim_templates: None,
+            },
+        );
+        let v = serde_json::to_value(&sb).unwrap();
+        assert_eq!(v["apiVersion"], "agents.x-k8s.io/v1beta1");
+        assert_eq!(v["kind"], "Sandbox");
+        assert_eq!(v["spec"]["service"], true);
+        assert_eq!(v["spec"]["operatingMode"], "Running");
+        assert!(v["spec"]["podTemplate"].is_object());
+    }
+
+    #[test]
+    fn status_reads_service_fqdn() {
+        let json = serde_json::json!({ "serviceFQDN": "demo-sbx.team-a.svc" });
+        let st: SandboxStatus = serde_json::from_value(json).unwrap();
+        assert_eq!(st.service_fqdn.as_deref(), Some("demo-sbx.team-a.svc"));
+    }
+}
+```
+
+- [ ] **Step 5: Run** `cargo test --lib sandbox` → PASS. Then `cargo run --bin crdgen > /tmp/x.yaml && diff <(cat deploy/crd/calibantask.yaml) /tmp/x.yaml` → **no diff** (enabling schemars must not change the CalibanTask CRD).
+
+- [ ] **Step 6: Commit** — `git add -A && git commit -m "feat(operator): foreign Sandbox type (agents.x-k8s.io/v1beta1) (#283)"`
+
+---
+
+### Task 2: Operator settings + object identity helpers
+
+**Files:**
+- Create: `src/config.rs`
+- Modify: `src/lib.rs` (add `pub mod config;`)
+
+**Interfaces:**
+- Produces:
+  - `Settings { caliband_image: String, caliband_port: i32, workspace_root: String, workspace_storage: String }` with `Settings::from_env()` and `Settings::default()`.
+  - `fn sandbox_name(t: &CalibanTask) -> String` (`<name>-sbx`), `sa_name` (`<name>-sa`), `netpol_name` (`<name>-netpol`).
+  - `fn common_labels(t: &CalibanTask) -> BTreeMap<String,String>`.
+  - `fn owner_ref(t: &CalibanTask) -> OwnerReference`.
+- Consumed by Tasks 3/4/5/6.
+
+**Context:** The caliband image is operator config, not CR intent (the CR declares intent). Defaults must be neutral/cluster-agnostic. `owner_ref` needs the task's `uid` (present on any cluster-fetched object; in unit tests we set it explicitly).
+
+- [ ] **Step 1: Write `src/config.rs`**
+
+```rust
+//! Operator-level settings (image, ports, workspace defaults) and helpers for
+//! naming and owning the child objects a reconcile creates. See ADR 0002.
+
+use std::collections::BTreeMap;
+
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
+use kube::{Resource, ResourceExt};
+
+use crate::crd::CalibanTask;
+
+/// Runtime configuration, sourced from the environment with neutral defaults.
+#[derive(Clone, Debug)]
+pub struct Settings {
+    /// Container image for the caliband pod.
+    pub caliband_image: String,
+    /// TCP+TLS port caliband listens on inside the pod.
+    pub caliband_port: i32,
+    /// Workspace root mount path in the pod.
+    pub workspace_root: String,
+    /// Requested size of the workspace PVC (e.g. `10Gi`).
+    pub workspace_storage: String,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            caliband_image: "ghcr.io/caliban-ai/caliban:latest".to_string(),
+            caliband_port: 8443,
+            workspace_root: "/work".to_string(),
+            workspace_storage: "10Gi".to_string(),
+        }
+    }
+}
+
+impl Settings {
+    /// Read settings from `CALIBAND_IMAGE`, `CALIBAND_PORT`, `CALIBAN_WORKSPACE_ROOT`,
+    /// `CALIBAN_WORKSPACE_STORAGE`, falling back to defaults.
+    pub fn from_env() -> Self {
+        let d = Self::default();
+        Self {
+            caliband_image: std::env::var("CALIBAND_IMAGE").unwrap_or(d.caliband_image),
+            caliband_port: std::env::var("CALIBAND_PORT")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(d.caliband_port),
+            workspace_root: std::env::var("CALIBAN_WORKSPACE_ROOT").unwrap_or(d.workspace_root),
+            workspace_storage: std::env::var("CALIBAN_WORKSPACE_STORAGE")
+                .unwrap_or(d.workspace_storage),
+        }
+    }
+}
+
+/// Name of the Sandbox backing a task.
+pub fn sandbox_name(t: &CalibanTask) -> String {
+    format!("{}-sbx", t.name_any())
+}
+/// Name of the task's dedicated ServiceAccount.
+pub fn sa_name(t: &CalibanTask) -> String {
+    format!("{}-sa", t.name_any())
+}
+/// Name of the task's NetworkPolicy.
+pub fn netpol_name(t: &CalibanTask) -> String {
+    format!("{}-netpol", t.name_any())
+}
+
+/// Labels stamped on every child object, keyed to the owning task.
+pub fn common_labels(t: &CalibanTask) -> BTreeMap<String, String> {
+    BTreeMap::from([
+        (
+            "app.kubernetes.io/managed-by".to_string(),
+            "caliban-operator".to_string(),
+        ),
+        (
+            "caliban.caliban-ai.dev/task".to_string(),
+            t.name_any(),
+        ),
+    ])
+}
+
+/// A controller owner reference to the task, so children cascade-delete.
+pub fn owner_ref(t: &CalibanTask) -> OwnerReference {
+    OwnerReference {
+        api_version: CalibanTask::api_version(&()).to_string(),
+        kind: CalibanTask::kind(&()).to_string(),
+        name: t.name_any(),
+        uid: t.uid().unwrap_or_default(),
+        controller: Some(true),
+        block_owner_deletion: Some(true),
+    }
+}
+```
+
+- [ ] **Step 2: Register the module** — add `pub mod config;` to `src/lib.rs`.
+
+- [ ] **Step 3: Write tests** (in `src/config.rs`)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crd::{CalibanTask, CalibanTaskSpec, Source, TaskSpec, Workspace};
+
+    fn task() -> CalibanTask {
+        let mut t = CalibanTask::new(
+            "refactor-auth",
+            CalibanTaskSpec {
+                workspace: Workspace {
+                    sources: vec![Source {
+                        name: "caliban".into(),
+                        repo: "git@x:caliban".into(),
+                        r#ref: "main".into(),
+                        path: "/work/caliban".into(),
+                    }],
+                    services: vec![],
+                },
+                task: TaskSpec { prompt: "hi".into(), agent_type: None },
+                model: None, state: None, isolation: None, resources: None, lifecycle: None,
+            },
+        );
+        t.metadata.namespace = Some("team-a".into());
+        t.metadata.uid = Some("uid-123".into());
+        t
+    }
+
+    #[test]
+    fn names_are_deterministic() {
+        let t = task();
+        assert_eq!(sandbox_name(&t), "refactor-auth-sbx");
+        assert_eq!(sa_name(&t), "refactor-auth-sa");
+        assert_eq!(netpol_name(&t), "refactor-auth-netpol");
+    }
+
+    #[test]
+    fn owner_ref_is_controller_with_uid() {
+        let o = owner_ref(&task());
+        assert_eq!(o.kind, "CalibanTask");
+        assert_eq!(o.api_version, "caliban.caliban-ai.dev/v1alpha1");
+        assert_eq!(o.name, "refactor-auth");
+        assert_eq!(o.uid, "uid-123");
+        assert_eq!(o.controller, Some(true));
+    }
+
+    #[test]
+    fn from_env_defaults_are_neutral() {
+        let s = Settings::default();
+        assert_eq!(s.caliband_port, 8443);
+        assert!(!s.caliband_image.contains("home"));
+        assert_eq!(s.workspace_root, "/work");
+    }
+}
+```
+
+- [ ] **Step 4: Run** `cargo test --lib config` → PASS.
+
+- [ ] **Step 5: Commit** — `git commit -am "feat(operator): reconcile settings + child naming/owner helpers (#283)"`
+
+---
+
+### Task 3: Build the ServiceAccount and NetworkPolicy
+
+**Files:**
+- Create: `src/resources.rs`
+- Modify: `src/lib.rs` (add `pub mod resources;`)
+
+**Interfaces:**
+- Consumes: `config::{sa_name, netpol_name, common_labels, owner_ref, Settings}`.
+- Produces: `fn build_service_account(t: &CalibanTask) -> ServiceAccount`, `fn build_network_policy(t: &CalibanTask, s: &Settings) -> NetworkPolicy`. Consumed by Task 5 (`plan`).
+
+**Context:** Least-privilege pod identity = token-less SA, no Role (ADR 0002 §4). The NetworkPolicy (ADR 0002 §5) is default-deny ingress+egress on the pod's own labels, plus: allow DNS egress (UDP+TCP 53), allow general egress (empty `to` = all destinations, for git clone / provider APIs), allow ingress on the caliband port. Selectors use the sandbox pod's labels — agent-sandbox stamps the Sandbox's own labels onto its pod; we select on our `common_labels`, which the Sandbox propagates via its podTemplate metadata (set in Task 4). No home-cluster identifiers.
+
+- [ ] **Step 1: Write `build_service_account` + `build_network_policy` in `src/resources.rs`**
+
+```rust
+//! Pure builders mapping a `CalibanTask` to the child objects a reconcile
+//! applies: a token-less ServiceAccount, a default-deny NetworkPolicy, and the
+//! backing agent-sandbox Sandbox. No cluster access — unit-tested. See ADR 0002.
+
+use std::collections::BTreeMap;
+
+use k8s_openapi::api::core::v1::ServiceAccount;
+use k8s_openapi::api::networking::v1::{
+    NetworkPolicy, NetworkPolicyEgressRule, NetworkPolicyIngressRule, NetworkPolicyPort,
+    NetworkPolicySpec,
+};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
+use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
+use kube::ResourceExt;
+
+use crate::config::{common_labels, netpol_name, owner_ref, sa_name, Settings};
+use crate::crd::CalibanTask;
+
+fn child_meta(t: &CalibanTask, name: String, labels: BTreeMap<String, String>) -> ObjectMeta {
+    ObjectMeta {
+        name: Some(name),
+        namespace: t.namespace(),
+        labels: Some(labels),
+        owner_references: Some(vec![owner_ref(t)]),
+        ..Default::default()
+    }
+}
+
+/// A dedicated, token-less ServiceAccount — the pod's least-privilege identity.
+pub fn build_service_account(t: &CalibanTask) -> ServiceAccount {
+    ServiceAccount {
+        metadata: child_meta(t, sa_name(t), common_labels(t)),
+        automount_service_account_token: Some(false),
+        ..Default::default()
+    }
+}
+
+fn np_port(proto: &str, port: i32) -> NetworkPolicyPort {
+    NetworkPolicyPort {
+        protocol: Some(proto.to_string()),
+        port: Some(IntOrString::Int(port)),
+        ..Default::default()
+    }
+}
+
+/// Default-deny NetworkPolicy: allow DNS + general egress + caliband-port ingress.
+pub fn build_network_policy(t: &CalibanTask, s: &Settings) -> NetworkPolicy {
+    NetworkPolicy {
+        metadata: child_meta(t, netpol_name(t), common_labels(t)),
+        spec: Some(NetworkPolicySpec {
+            // Select the sandbox pod by the labels we propagate into its template.
+            pod_selector: LabelSelector {
+                match_labels: Some(common_labels(t)),
+                ..Default::default()
+            },
+            policy_types: Some(vec!["Ingress".to_string(), "Egress".to_string()]),
+            // Ingress: caliband port only.
+            ingress: Some(vec![NetworkPolicyIngressRule {
+                ports: Some(vec![np_port("TCP", s.caliband_port)]),
+                ..Default::default()
+            }]),
+            // Egress: DNS (53 UDP+TCP), then everything else (git/providers).
+            egress: Some(vec![
+                NetworkPolicyEgressRule {
+                    ports: Some(vec![np_port("UDP", 53), np_port("TCP", 53)]),
+                    ..Default::default()
+                },
+                NetworkPolicyEgressRule::default(),
+            ]),
+        }),
+    }
+}
+```
+
+- [ ] **Step 2: Register the module** — add `pub mod resources;` to `src/lib.rs`.
+
+- [ ] **Step 3: Write tests** (in `src/resources.rs`; reuse a `task()` helper like Task 2's — define a local `fn task() -> CalibanTask` in this test module)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // ... local `fn task() -> CalibanTask { ... }` (namespace "team-a", uid set) ...
+
+    #[test]
+    fn service_account_is_token_less_and_owned() {
+        let sa = build_service_account(&task());
+        assert_eq!(sa.metadata.name.as_deref(), Some("refactor-auth-sa"));
+        assert_eq!(sa.metadata.namespace.as_deref(), Some("team-a"));
+        assert_eq!(sa.automount_service_account_token, Some(false));
+        let owners = sa.metadata.owner_references.unwrap();
+        assert_eq!(owners[0].controller, Some(true));
+        assert_eq!(owners[0].kind, "CalibanTask");
+    }
+
+    #[test]
+    fn network_policy_is_default_deny_with_dns_and_caliband_ingress() {
+        let np = build_network_policy(&task(), &Settings::default());
+        let spec = np.spec.unwrap();
+        assert_eq!(
+            spec.policy_types.as_ref().unwrap(),
+            &vec!["Ingress".to_string(), "Egress".to_string()]
+        );
+        // Ingress allows the caliband port.
+        let iports = spec.ingress.unwrap()[0].ports.clone().unwrap();
+        assert!(iports.iter().any(|p| p.port == Some(IntOrString::Int(8443))));
+        // Egress: DNS rule + an allow-all rule (empty `to`).
+        let egress = spec.egress.unwrap();
+        assert_eq!(egress.len(), 2);
+        assert!(egress[1].to.is_none()); // allow-all destinations
+        // Selects the pod by our managed labels.
+        assert!(spec
+            .pod_selector
+            .match_labels
+            .unwrap()
+            .contains_key("caliban.caliban-ai.dev/task"));
+    }
+}
+```
+
+- [ ] **Step 4: Run** `cargo test --lib resources` → PASS.
+
+- [ ] **Step 5: Commit** — `git commit -am "feat(operator): build token-less SA + default-deny NetworkPolicy (#283)"`
+
+---
+
+### Task 4: Build the Sandbox (podTemplate, workspace PVC, env)
+
+**Files:**
+- Modify: `src/resources.rs` (add `build_sandbox`)
+
+**Interfaces:**
+- Consumes: `sandbox::{Sandbox, SandboxSpec}`, `config::{sandbox_name, sa_name, common_labels, owner_ref, Settings}`, the `CalibanTask` spec.
+- Produces: `fn build_sandbox(t: &CalibanTask, s: &Settings) -> Sandbox`. Consumed by Task 5 (`plan`).
+
+**Context:** The podTemplate carries one caliband container (image + port `s.caliband_port`, env, workspace volume mount at `s.workspace_root`), the task's `runtimeClass` (from `spec.isolation.runtime_class`, else unset → cluster default), the token-less SA (`sa_name`, automount off), and `common_labels` on the pod (so the NetworkPolicy selects it). The workspace PVC is a `volumeClaimTemplates` entry (RWO, `s.workspace_storage`, storageClass unset → cluster default). `service: true`; `operatingMode: Running`. Env projected: `CALIBAND_LISTEN=tcp://0.0.0.0:<port>`, `CALIBAN_WORKSPACE_ROOT=<root>`, `CALIBAN_WORKSPACE_SOURCES=<json of sources>`, and `GONZALO_ENDPOINT` if `spec.state.gonzalo_endpoint` is set. The operator does not clone sources — caliband does (workspace-scoped caliband, caliban#281); env is the provisioning contract.
+
+- [ ] **Step 1: Add `build_sandbox` (and helpers) to `src/resources.rs`**
+
+```rust
+use k8s_openapi::api::core::v1::{
+    Container, ContainerPort, EnvVar, PersistentVolumeClaim, PersistentVolumeClaimSpec, PodSpec,
+    PodTemplateSpec, VolumeMount, VolumeResourceRequirements,
+};
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use crate::config::{sandbox_name, Settings};
+use crate::sandbox::{Sandbox, SandboxSpec};
+
+const WORKSPACE_VOLUME: &str = "workspace";
+
+fn env(name: &str, value: String) -> EnvVar {
+    EnvVar { name: name.to_string(), value: Some(value), ..Default::default() }
+}
+
+fn caliband_env(t: &CalibanTask, s: &Settings) -> Vec<EnvVar> {
+    let sources = serde_json::to_string(&t.spec.workspace.sources).unwrap_or_else(|_| "[]".into());
+    let mut e = vec![
+        env("CALIBAND_LISTEN", format!("tcp://0.0.0.0:{}", s.caliband_port)),
+        env("CALIBAN_WORKSPACE_ROOT", s.workspace_root.clone()),
+        env("CALIBAN_WORKSPACE_SOURCES", sources),
+    ];
+    if let Some(ep) = t.spec.state.as_ref().and_then(|st| st.gonzalo_endpoint.clone()) {
+        e.push(env("GONZALO_ENDPOINT", ep));
+    }
+    e
+}
+
+fn workspace_pvc(t: &CalibanTask, s: &Settings) -> PersistentVolumeClaim {
+    PersistentVolumeClaim {
+        metadata: ObjectMeta { name: Some(WORKSPACE_VOLUME.to_string()), ..Default::default() },
+        spec: Some(PersistentVolumeClaimSpec {
+            access_modes: Some(vec!["ReadWriteOnce".to_string()]),
+            resources: Some(VolumeResourceRequirements {
+                requests: Some(BTreeMap::from([(
+                    "storage".to_string(),
+                    Quantity(s.workspace_storage.clone()),
+                )])),
+                ..Default::default()
+            }),
+            // storageClassName unset → cluster default (cluster-agnostic).
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+/// Map a `CalibanTask` to its backing agent-sandbox `Sandbox`.
+pub fn build_sandbox(t: &CalibanTask, s: &Settings) -> Sandbox {
+    let labels = common_labels(t);
+    let container = Container {
+        name: "caliband".to_string(),
+        image: Some(s.caliband_image.clone()),
+        ports: Some(vec![ContainerPort {
+            container_port: s.caliband_port,
+            name: Some("caliband".to_string()),
+            ..Default::default()
+        }]),
+        env: Some(caliband_env(t, s)),
+        volume_mounts: Some(vec![VolumeMount {
+            name: WORKSPACE_VOLUME.to_string(),
+            mount_path: s.workspace_root.clone(),
+            ..Default::default()
+        }]),
+        ..Default::default()
+    };
+    let pod_spec = PodSpec {
+        containers: vec![container],
+        runtime_class_name: t.spec.isolation.as_ref().and_then(|i| i.runtime_class.clone()),
+        service_account_name: Some(sa_name(t)),
+        automount_service_account_token: Some(false),
+        ..Default::default()
+    };
+    let mut sb = Sandbox::new(
+        &sandbox_name(t),
+        SandboxSpec {
+            pod_template: PodTemplateSpec {
+                metadata: Some(ObjectMeta { labels: Some(labels.clone()), ..Default::default() }),
+                spec: Some(pod_spec),
+            },
+            service: Some(true),
+            operating_mode: Some("Running".to_string()),
+            volume_claim_templates: Some(vec![workspace_pvc(t, s)]),
+        },
+    );
+    sb.metadata.namespace = t.namespace();
+    sb.metadata.labels = Some(labels);
+    sb.metadata.owner_references = Some(vec![owner_ref(t)]);
+    sb
+}
+```
+
+- [ ] **Step 2: Write tests** (append to the `resources` test module)
+
+```rust
+#[test]
+fn sandbox_has_caliband_container_pvc_and_service() {
+    let s = Settings::default();
+    let sb = build_sandbox(&task(), &s);
+    assert_eq!(sb.metadata.name.as_deref(), Some("refactor-auth-sbx"));
+    assert_eq!(sb.metadata.namespace.as_deref(), Some("team-a"));
+    assert_eq!(sb.spec.service, Some(true));
+    let pod = sb.spec.pod_template.spec.unwrap();
+    assert_eq!(pod.service_account_name.as_deref(), Some("refactor-auth-sa"));
+    assert_eq!(pod.automount_service_account_token, Some(false));
+    let c = &pod.containers[0];
+    assert_eq!(c.image.as_deref(), Some("ghcr.io/caliban-ai/caliban:latest"));
+    assert_eq!(c.ports.as_ref().unwrap()[0].container_port, 8443);
+    // Env projects the listen addr + workspace root.
+    let env = c.env.as_ref().unwrap();
+    assert!(env.iter().any(|e| e.name == "CALIBAND_LISTEN"
+        && e.value.as_deref() == Some("tcp://0.0.0.0:8443")));
+    assert!(env.iter().any(|e| e.name == "CALIBAN_WORKSPACE_ROOT"));
+    // Workspace PVC present.
+    let pvcs = sb.spec.volume_claim_templates.unwrap();
+    assert_eq!(pvcs[0].metadata.name.as_deref(), Some("workspace"));
+    // Pod carries the managed labels (so the NetworkPolicy selects it).
+    assert!(sb.spec.pod_template.metadata.unwrap().labels.unwrap()
+        .contains_key("caliban.caliban-ai.dev/task"));
+}
+
+#[test]
+fn sandbox_runtime_class_from_isolation() {
+    use crate::crd::IsolationSpec;
+    let mut t = task();
+    t.spec.isolation = Some(IsolationSpec {
+        runtime_class: Some("gvisor".into()),
+        worktrees: None,
+    });
+    let sb = build_sandbox(&t, &Settings::default());
+    assert_eq!(
+        sb.spec.pod_template.spec.unwrap().runtime_class_name.as_deref(),
+        Some("gvisor")
+    );
+}
+```
+
+- [ ] **Step 3: Run** `cargo test --lib resources` → PASS.
+
+- [ ] **Step 4: Commit** — `git commit -am "feat(operator): build caliband Sandbox from CalibanTask (#283)"`
+
+---
+
+### Task 5: Reconcile plan aggregator + status derivation
+
+**Files:**
+- Modify: `src/resources.rs` (add `ReconcilePlan` + `plan`)
+- Modify: `src/controller.rs` (replace `desired_status` with `derive_status`)
+
+**Interfaces:**
+- Produces:
+  - `struct ReconcilePlan { pub service_account: ServiceAccount, pub network_policy: NetworkPolicy, pub sandbox: Sandbox }` and `fn plan(t: &CalibanTask, s: &Settings) -> ReconcilePlan`.
+  - `fn derive_status(t: &CalibanTask, sandbox: Option<&Sandbox>, s: &Settings) -> Option<CalibanTaskStatus>` — returns `Some(new)` only when it differs from `t.status`, else `None`.
+- Consumed by Task 6 (reconcile).
+
+**Context:** `derive_status` (ADR 0002 §6) supersedes #282's `desired_status`: `Provisioning` once we have applied a Sandbox but it has no `serviceFQDN`; `Running` with `calibandEndpoint = "<serviceFQDN>:<port>"` + `sandboxRef` once `serviceFQDN` is populated. `Pending` is the value before the first apply (when `sandbox` is `None`). Skip the patch when the derived status equals the observed one. Delete `desired_status` and its tests; move status logic here so the controller stays thin.
+
+- [ ] **Step 1: Add `ReconcilePlan` + `plan` to `src/resources.rs`**
+
+```rust
+/// The child objects a single reconcile applies.
+pub struct ReconcilePlan {
+    pub service_account: ServiceAccount,
+    pub network_policy: NetworkPolicy,
+    pub sandbox: Sandbox,
+}
+
+/// Assemble every child object for a task (pure).
+pub fn plan(t: &CalibanTask, s: &Settings) -> ReconcilePlan {
+    ReconcilePlan {
+        service_account: build_service_account(t),
+        network_policy: build_network_policy(t, s),
+        sandbox: build_sandbox(t, s),
+    }
+}
+```
+
+- [ ] **Step 2: Test `plan`** (append to `resources` tests)
+
+```rust
+#[test]
+fn plan_names_all_three_children() {
+    let p = plan(&task(), &Settings::default());
+    assert_eq!(p.service_account.metadata.name.as_deref(), Some("refactor-auth-sa"));
+    assert_eq!(p.network_policy.metadata.name.as_deref(), Some("refactor-auth-netpol"));
+    assert_eq!(p.sandbox.metadata.name.as_deref(), Some("refactor-auth-sbx"));
+}
+```
+
+- [ ] **Step 3: Replace `desired_status` with `derive_status` in `src/controller.rs`**
+
+Remove `desired_status` and its four unit tests. Add:
+
+```rust
+use crate::config::{sandbox_name, Settings};
+use crate::crd::{NamedRef, Phase};
+use crate::sandbox::Sandbox;
+
+/// Derive the CalibanTask status from the task + its backing Sandbox. Returns
+/// `Some(new_status)` only when it differs from the observed status (no-op churn
+/// avoidance), else `None`. See ADR 0002 §6.
+pub(crate) fn derive_status(
+    t: &CalibanTask,
+    sandbox: Option<&Sandbox>,
+    s: &Settings,
+) -> Option<CalibanTaskStatus> {
+    let fqdn = sandbox
+        .and_then(|sb| sb.status.as_ref())
+        .and_then(|st| st.service_fqdn.clone());
+    let (phase, endpoint) = match (sandbox, fqdn) {
+        (None, _) => (Phase::Pending, None),
+        (Some(_), None) => (Phase::Provisioning, None),
+        (Some(_), Some(f)) => (Phase::Running, Some(format!("{}:{}", f, s.caliband_port))),
+    };
+    let mut next = t.status.clone().unwrap_or_default();
+    next.phase = phase;
+    next.caliband_endpoint = endpoint;
+    if sandbox.is_some() {
+        next.sandbox_ref = Some(NamedRef { name: sandbox_name(t) });
+    }
+    match &t.status {
+        Some(cur) if status_eq(cur, &next) => None,
+        _ => Some(next),
+    }
+}
+
+fn status_eq(a: &CalibanTaskStatus, b: &CalibanTaskStatus) -> bool {
+    a.phase == b.phase
+        && a.caliband_endpoint == b.caliband_endpoint
+        && a.sandbox_ref.as_ref().map(|r| &r.name) == b.sandbox_ref.as_ref().map(|r| &r.name)
+}
+```
+
+- [ ] **Step 4: Write `derive_status` tests** (in `controller.rs` tests)
+
+```rust
+#[test]
+fn no_sandbox_yields_pending() {
+    let t = task_without_status();
+    let d = super::derive_status(&t, None, &Settings::default()).unwrap();
+    assert_eq!(d.phase, Phase::Pending);
+    assert!(d.caliband_endpoint.is_none());
+}
+
+#[test]
+fn sandbox_without_fqdn_is_provisioning() {
+    let t = task_without_status();
+    let sb = sandbox_with_fqdn(None);
+    let d = super::derive_status(&t, Some(&sb), &Settings::default()).unwrap();
+    assert_eq!(d.phase, Phase::Provisioning);
+    assert_eq!(d.sandbox_ref.unwrap().name, "refactor-auth-sbx");
+}
+
+#[test]
+fn sandbox_with_fqdn_is_running_with_endpoint() {
+    let t = task_without_status();
+    let sb = sandbox_with_fqdn(Some("refactor-auth-sbx.team-a.svc"));
+    let d = super::derive_status(&t, Some(&sb), &Settings::default()).unwrap();
+    assert_eq!(d.phase, Phase::Running);
+    assert_eq!(d.caliband_endpoint.as_deref(), Some("refactor-auth-sbx.team-a.svc:8443"));
+}
+
+#[test]
+fn unchanged_status_is_noop() {
+    let mut t = task_without_status();
+    let sb = sandbox_with_fqdn(Some("refactor-auth-sbx.team-a.svc"));
+    // First derivation, then apply it as the observed status.
+    t.status = super::derive_status(&t, Some(&sb), &Settings::default());
+    assert!(super::derive_status(&t, Some(&sb), &Settings::default()).is_none());
+}
+```
+(Add `task_without_status()` and `sandbox_with_fqdn(Option<&str>) -> Sandbox` test helpers: build a `CalibanTask` named `refactor-auth`/ns `team-a`/uid set with `status: None`; and a `Sandbox` whose `.status = Some(SandboxStatus { service_fqdn: ... })`.)
+
+- [ ] **Step 5: Run** `cargo test --lib` → PASS (controller + resources).
+
+- [ ] **Step 6: Commit** — `git commit -am "feat(operator): reconcile plan + Sandbox-driven status derivation (#283)"`
+
+---
+
+### Task 6: Wire the async reconcile (apply plan + patch status)
+
+**Files:**
+- Modify: `src/controller.rs` (rewrite `reconcile`, `Context`, `run`)
+- Modify: `src/bin/caliban-operator.rs` (pass `Settings::from_env()`)
+- Modify: `src/lib.rs` (re-export `sandbox`, `config`, `resources` as needed)
+
+**Interfaces:**
+- Consumes: `resources::plan`, `derive_status`, `sandbox::Sandbox`, `config::{Settings, sandbox_name}`.
+
+**Context:** The reconcile applies the three children by server-side apply (owner-referenced), reads the Sandbox back, derives status, and patches it. `Context` gains `settings: Settings`. Apply uses `PatchParams::apply("caliban-operator").force()`. This glue is not unit-tested (no cluster); correctness rides on the pure tests + home-cluster QA. Keep it minimal and legible.
+
+- [ ] **Step 1: Rewrite `reconcile`, `Context`, `run` in `src/controller.rs`**
+
+```rust
+use kube::api::{Patch, PatchParams};
+use crate::config::{sandbox_name, Settings};
+use crate::resources::plan;
+use crate::sandbox::Sandbox;
+
+/// Shared reconcile context.
+pub struct Context {
+    /// Kubernetes client.
+    pub client: Client,
+    /// Operator settings.
+    pub settings: Settings,
+}
+
+async fn apply<K>(api: &Api<K>, name: &str, obj: &K) -> Result<(), Error>
+where
+    K: Clone + std::fmt::Debug + serde::Serialize + serde::de::DeserializeOwned,
+{
+    let pp = PatchParams::apply("caliban-operator").force();
+    api.patch(name, &pp, &Patch::Apply(obj)).await?;
+    Ok(())
+}
+
+async fn reconcile(obj: Arc<CalibanTask>, ctx: Arc<Context>) -> Result<Action, Error> {
+    let ns = obj.namespace().unwrap_or_default();
+    let name = obj.name_any();
+    let s = &ctx.settings;
+    let p = plan(&obj, s);
+
+    // Apply children (idempotent SSA; owner refs cascade-delete).
+    let sa_api: Api<ServiceAccount> = Api::namespaced(ctx.client.clone(), &ns);
+    apply(&sa_api, &p.service_account.name_any(), &p.service_account).await?;
+    let np_api: Api<NetworkPolicy> = Api::namespaced(ctx.client.clone(), &ns);
+    apply(&np_api, &p.network_policy.name_any(), &p.network_policy).await?;
+    let sb_api: Api<Sandbox> = Api::namespaced(ctx.client.clone(), &ns);
+    apply(&sb_api, &p.sandbox.name_any(), &p.sandbox).await?;
+
+    // Read the Sandbox back for its status, then derive + patch CalibanTask status.
+    let sandbox = sb_api.get_opt(&sandbox_name(&obj)).await?;
+    if let Some(status) = super::controller::derive_status(&obj, sandbox.as_ref(), s) {
+        let task_api: Api<CalibanTask> = Api::namespaced(ctx.client.clone(), &ns);
+        let patch = serde_json::json!({ "status": status });
+        task_api
+            .patch_status(&name, &PatchParams::default(), &Patch::Merge(&patch))
+            .await?;
+        tracing::info!(%ns, %name, ?status.phase, "patched CalibanTask status");
+    }
+    Ok(Action::requeue(Duration::from_secs(30)))
+}
+```
+(Adjust imports: `ServiceAccount`, `NetworkPolicy` from k8s-openapi; `derive_status` is in this module so call it directly. Add `serde::de::DeserializeOwned` bound imports as needed. `ResourceExt` is already imported.)
+
+- [ ] **Step 2: Update `run` to build `Settings`**
+
+```rust
+pub async fn run(client: Client) -> anyhow::Result<()> {
+    let tasks: Api<CalibanTask> = Api::all(client.clone());
+    let ctx = Arc::new(Context { client, settings: Settings::from_env() });
+    Controller::new(tasks, Config::default())
+        .run(reconcile, error_policy, ctx)
+        .for_each(|res| async move {
+            match res {
+                Ok((obj, _action)) => tracing::debug!(?obj, "reconciled"),
+                Err(e) => tracing::warn!(error = %e, "controller error"),
+            }
+        })
+        .await;
+    Ok(())
+}
+```
+(`src/bin/caliban-operator.rs` still calls `controller::run(client)`; no change needed there since `run` now reads env itself. Leave the bin as-is unless imports break.)
+
+- [ ] **Step 3: Run the gate** — `cargo fmt --all`, then `cargo clippy --workspace --all-targets -- -D warnings`, `cargo build --workspace --all-targets`, `cargo test --workspace`. All PASS.
+
+- [ ] **Step 4: Regenerate + verify the CalibanTask CRD is unchanged** — `cargo run --bin crdgen > deploy/crd/calibantask.yaml && git diff --exit-code deploy/crd/calibantask.yaml` → no diff (the `committed_crd_yaml_is_in_sync` test also guards this).
+
+- [ ] **Step 5: Commit** — `git commit -am "feat(operator): reconcile CalibanTask → Sandbox + SA + NetworkPolicy, status from serviceFQDN (#283)"`
+
+---
+
+## Notes for the executor
+
+- **Deferred (ADR 0002 §7), do not implement here:** the drain finalizer, idle→pause/resume, `SandboxTemplate`/warm pools, full Secret/ConfigMap credential projection. Flag scope creep toward these as over-building.
+- **Test helper duplication:** each test module needs a `task()`/`task_without_status()` builder. A small amount of per-module duplication is fine (test-local fixtures); do not build a shared test crate for it.
+- **The operator's own cluster RBAC** (permission to create Sandboxes/SAs/NetworkPolicies, patch `calibantasks/status`) is #284 (the chart), not this ticket. ADR 0002 §Consequences fixes the verb set that chart must grant.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,148 @@
+//! Operator-level settings (image, ports, workspace defaults) and helpers for
+//! naming and owning the child objects a reconcile creates. See ADR 0002.
+
+use std::collections::BTreeMap;
+
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
+use kube::{Resource, ResourceExt};
+
+use crate::crd::CalibanTask;
+
+/// Runtime configuration, sourced from the environment with neutral defaults.
+#[derive(Clone, Debug)]
+pub struct Settings {
+    /// Container image for the caliband pod.
+    pub caliband_image: String,
+    /// TCP+TLS port caliband listens on inside the pod.
+    pub caliband_port: i32,
+    /// Workspace root mount path in the pod.
+    pub workspace_root: String,
+    /// Requested size of the workspace PVC (e.g. `10Gi`).
+    pub workspace_storage: String,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            caliband_image: "ghcr.io/caliban-ai/caliban:latest".to_string(),
+            caliband_port: 8443,
+            workspace_root: "/work".to_string(),
+            workspace_storage: "10Gi".to_string(),
+        }
+    }
+}
+
+impl Settings {
+    /// Read settings from `CALIBAND_IMAGE`, `CALIBAND_PORT`, `CALIBAN_WORKSPACE_ROOT`,
+    /// `CALIBAN_WORKSPACE_STORAGE`, falling back to defaults.
+    pub fn from_env() -> Self {
+        let d = Self::default();
+        Self {
+            caliband_image: std::env::var("CALIBAND_IMAGE").unwrap_or(d.caliband_image),
+            caliband_port: std::env::var("CALIBAND_PORT")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(d.caliband_port),
+            workspace_root: std::env::var("CALIBAN_WORKSPACE_ROOT").unwrap_or(d.workspace_root),
+            workspace_storage: std::env::var("CALIBAN_WORKSPACE_STORAGE")
+                .unwrap_or(d.workspace_storage),
+        }
+    }
+}
+
+/// Name of the Sandbox backing a task.
+pub fn sandbox_name(t: &CalibanTask) -> String {
+    format!("{}-sbx", t.name_any())
+}
+/// Name of the task's dedicated ServiceAccount.
+pub fn sa_name(t: &CalibanTask) -> String {
+    format!("{}-sa", t.name_any())
+}
+/// Name of the task's NetworkPolicy.
+pub fn netpol_name(t: &CalibanTask) -> String {
+    format!("{}-netpol", t.name_any())
+}
+
+/// Labels stamped on every child object, keyed to the owning task.
+pub fn common_labels(t: &CalibanTask) -> BTreeMap<String, String> {
+    BTreeMap::from([
+        (
+            "app.kubernetes.io/managed-by".to_string(),
+            "caliban-operator".to_string(),
+        ),
+        ("caliban.caliban-ai.dev/task".to_string(), t.name_any()),
+    ])
+}
+
+/// A controller owner reference to the task, so children cascade-delete.
+pub fn owner_ref(t: &CalibanTask) -> OwnerReference {
+    OwnerReference {
+        api_version: CalibanTask::api_version(&()).to_string(),
+        kind: CalibanTask::kind(&()).to_string(),
+        name: t.name_any(),
+        uid: t.uid().unwrap_or_default(),
+        controller: Some(true),
+        block_owner_deletion: Some(true),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crd::{CalibanTask, CalibanTaskSpec, Source, TaskSpec, Workspace};
+
+    fn task() -> CalibanTask {
+        let mut t = CalibanTask::new(
+            "refactor-auth",
+            CalibanTaskSpec {
+                workspace: Workspace {
+                    sources: vec![Source {
+                        name: "caliban".into(),
+                        repo: "git@x:caliban".into(),
+                        r#ref: "main".into(),
+                        path: "/work/caliban".into(),
+                    }],
+                    services: vec![],
+                },
+                task: TaskSpec {
+                    prompt: "hi".into(),
+                    agent_type: None,
+                },
+                model: None,
+                state: None,
+                isolation: None,
+                resources: None,
+                lifecycle: None,
+            },
+        );
+        t.metadata.namespace = Some("team-a".into());
+        t.metadata.uid = Some("uid-123".into());
+        t
+    }
+
+    #[test]
+    fn names_are_deterministic() {
+        let t = task();
+        assert_eq!(sandbox_name(&t), "refactor-auth-sbx");
+        assert_eq!(sa_name(&t), "refactor-auth-sa");
+        assert_eq!(netpol_name(&t), "refactor-auth-netpol");
+    }
+
+    #[test]
+    fn owner_ref_is_controller_with_uid() {
+        let o = owner_ref(&task());
+        assert_eq!(o.kind, "CalibanTask");
+        assert_eq!(o.api_version, "caliban.caliban-ai.dev/v1alpha1");
+        assert_eq!(o.name, "refactor-auth");
+        assert_eq!(o.uid, "uid-123");
+        assert_eq!(o.controller, Some(true));
+    }
+
+    #[test]
+    fn from_env_defaults_are_neutral() {
+        let s = Settings::default();
+        assert_eq!(s.caliband_port, 8443);
+        assert!(!s.caliband_image.contains("home"));
+        assert_eq!(s.workspace_root, "/work");
+    }
+}

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -12,7 +12,9 @@ use kube::runtime::watcher::Config;
 use kube::runtime::Controller;
 use kube::{Api, Client, ResourceExt};
 
-use crate::crd::{CalibanTask, CalibanTaskStatus, Phase};
+use crate::config::{sandbox_name, Settings};
+use crate::crd::{CalibanTask, CalibanTaskStatus, NamedRef, Phase};
+use crate::sandbox::Sandbox;
 
 /// Controller error.
 #[derive(thiserror::Error, Debug)]
@@ -31,17 +33,40 @@ pub struct Context {
     pub client: Client,
 }
 
-/// The pure status decision (unit-testable; see tests).
-pub(crate) fn desired_status(current: Option<&CalibanTaskStatus>) -> Option<CalibanTaskStatus> {
-    match current {
-        // No status yet: initialize to Pending (#282). Once any status exists —
-        // Pending or progressed by #283's reconcile — leave it untouched.
-        None => Some(CalibanTaskStatus {
-            phase: Phase::Pending,
-            ..Default::default()
-        }),
-        Some(_) => None,
+/// Derive the CalibanTask status from the task + its backing Sandbox. Returns
+/// `Some(new_status)` only when it differs from the observed status (no-op churn
+/// avoidance), else `None`. See ADR 0002 §6.
+pub(crate) fn derive_status(
+    t: &CalibanTask,
+    sandbox: Option<&Sandbox>,
+    s: &Settings,
+) -> Option<CalibanTaskStatus> {
+    let fqdn = sandbox
+        .and_then(|sb| sb.status.as_ref())
+        .and_then(|st| st.service_fqdn.clone());
+    let (phase, endpoint) = match (sandbox, fqdn) {
+        (None, _) => (Phase::Pending, None),
+        (Some(_), None) => (Phase::Provisioning, None),
+        (Some(_), Some(f)) => (Phase::Running, Some(format!("{}:{}", f, s.caliband_port))),
+    };
+    let mut next = t.status.clone().unwrap_or_default();
+    next.phase = phase;
+    next.caliband_endpoint = endpoint;
+    if sandbox.is_some() {
+        next.sandbox_ref = Some(NamedRef {
+            name: sandbox_name(t),
+        });
     }
+    match &t.status {
+        Some(cur) if status_eq(cur, &next) => None,
+        _ => Some(next),
+    }
+}
+
+fn status_eq(a: &CalibanTaskStatus, b: &CalibanTaskStatus) -> bool {
+    a.phase == b.phase
+        && a.caliband_endpoint == b.caliband_endpoint
+        && a.sandbox_ref.as_ref().map(|r| &r.name) == b.sandbox_ref.as_ref().map(|r| &r.name)
 }
 
 async fn reconcile(obj: Arc<CalibanTask>, ctx: Arc<Context>) -> Result<Action, Error> {
@@ -49,7 +74,7 @@ async fn reconcile(obj: Arc<CalibanTask>, ctx: Arc<Context>) -> Result<Action, E
     let name = obj.name_any();
     let api: Api<CalibanTask> = Api::namespaced(ctx.client.clone(), &ns);
 
-    if let Some(status) = desired_status(obj.status.as_ref()) {
+    if let Some(status) = derive_status(&obj, None, &Settings::from_env()) {
         let patch = serde_json::json!({ "status": status });
         api.patch_status(&name, &PatchParams::default(), &Patch::Merge(&patch))
             .await?;
@@ -82,39 +107,93 @@ pub async fn run(client: Client) -> anyhow::Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use crate::crd::{CalibanTaskStatus, Phase};
+    use super::*;
+    use crate::crd::{CalibanTaskSpec, Source, TaskSpec, Workspace};
+    use crate::sandbox::{SandboxSpec, SandboxStatus};
+    use k8s_openapi::api::core::v1::PodTemplateSpec;
+
+    fn task_without_status() -> CalibanTask {
+        let mut t = CalibanTask::new(
+            "refactor-auth",
+            CalibanTaskSpec {
+                workspace: Workspace {
+                    sources: vec![Source {
+                        name: "caliban".into(),
+                        repo: "git@x:caliban".into(),
+                        r#ref: "main".into(),
+                        path: "/work/caliban".into(),
+                    }],
+                    services: vec![],
+                },
+                task: TaskSpec {
+                    prompt: "hi".into(),
+                    agent_type: None,
+                },
+                model: None,
+                state: None,
+                isolation: None,
+                resources: None,
+                lifecycle: None,
+            },
+        );
+        t.metadata.namespace = Some("team-a".into());
+        t.metadata.uid = Some("uid-123".into());
+        t.status = None;
+        t
+    }
+
+    fn sandbox_with_fqdn(fqdn: Option<&str>) -> Sandbox {
+        let mut sb = Sandbox::new(
+            "refactor-auth-sbx",
+            SandboxSpec {
+                pod_template: PodTemplateSpec::default(),
+                service: Some(true),
+                operating_mode: Some("Running".to_string()),
+                volume_claim_templates: None,
+            },
+        );
+        sb.metadata.namespace = Some("team-a".into());
+        sb.status = Some(SandboxStatus {
+            service_fqdn: fqdn.map(|f| f.to_string()),
+        });
+        sb
+    }
 
     #[test]
-    fn initializes_absent_status_to_pending() {
-        let d = super::desired_status(None).expect("should set status");
+    fn no_sandbox_yields_pending() {
+        let t = task_without_status();
+        let d = super::derive_status(&t, None, &Settings::default()).unwrap();
         assert_eq!(d.phase, Phase::Pending);
+        assert!(d.caliband_endpoint.is_none());
     }
 
     #[test]
-    fn leaves_running_status_untouched() {
-        let running = CalibanTaskStatus {
-            phase: Phase::Running,
-            ..Default::default()
-        };
-        assert!(super::desired_status(Some(&running)).is_none());
+    fn sandbox_without_fqdn_is_provisioning() {
+        let t = task_without_status();
+        let sb = sandbox_with_fqdn(None);
+        let d = super::derive_status(&t, Some(&sb), &Settings::default()).unwrap();
+        assert_eq!(d.phase, Phase::Provisioning);
+        assert_eq!(d.sandbox_ref.unwrap().name, "refactor-auth-sbx");
     }
 
     #[test]
-    fn does_not_repatch_already_pending_status() {
-        let pending = CalibanTaskStatus {
-            phase: Phase::Pending,
-            ..Default::default()
-        };
-        assert!(super::desired_status(Some(&pending)).is_none());
+    fn sandbox_with_fqdn_is_running_with_endpoint() {
+        let t = task_without_status();
+        let sb = sandbox_with_fqdn(Some("refactor-auth-sbx.team-a.svc"));
+        let d = super::derive_status(&t, Some(&sb), &Settings::default()).unwrap();
+        assert_eq!(d.phase, Phase::Running);
+        assert_eq!(
+            d.caliband_endpoint.as_deref(),
+            Some("refactor-auth-sbx.team-a.svc:8443")
+        );
     }
 
     #[test]
-    fn leaves_pending_with_endpoint_untouched() {
-        let pending_with_endpoint = CalibanTaskStatus {
-            phase: Phase::Pending,
-            caliband_endpoint: Some("10.0.0.1:9000".to_string()),
-            ..Default::default()
-        };
-        assert!(super::desired_status(Some(&pending_with_endpoint)).is_none());
+    fn unchanged_status_is_noop() {
+        let mut t = task_without_status();
+        let sb = sandbox_with_fqdn(Some("refactor-auth-sbx.team-a.svc"));
+        // First derivation, then apply it as the observed status.
+        t.status = super::derive_status(&t, Some(&sb), &Settings::default());
+        assert!(super::derive_status(&t, Some(&sb), &Settings::default()).is_none());
     }
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,19 +1,23 @@
-//! CalibanTask controller. #282: a no-op reconcile that initializes status to
-//! Pending. The real reconcile (→ agent-sandbox Sandbox + RBAC/NetworkPolicy) is
-//! caliban-ai/caliban#283.
+//! CalibanTask controller (#283): reconciles a `CalibanTask` into its child
+//! objects — a token-less ServiceAccount, a default-deny NetworkPolicy, and the
+//! backing agent-sandbox Sandbox — via server-side apply, then derives and
+//! patches the task's status from the Sandbox's observed state.
 
 use std::sync::Arc;
 use std::time::Duration;
 
 use futures::StreamExt as _;
+use k8s_openapi::api::core::v1::ServiceAccount;
+use k8s_openapi::api::networking::v1::NetworkPolicy;
 use kube::api::{Patch, PatchParams};
 use kube::runtime::controller::Action;
 use kube::runtime::watcher::Config;
 use kube::runtime::Controller;
-use kube::{Api, Client, ResourceExt};
+use kube::{Api, Client, Resource, ResourceExt};
 
 use crate::config::{sandbox_name, Settings};
 use crate::crd::{CalibanTask, CalibanTaskStatus, NamedRef, Phase};
+use crate::resources::plan;
 use crate::sandbox::Sandbox;
 
 /// Controller error.
@@ -31,6 +35,8 @@ pub enum Error {
 pub struct Context {
     /// Kubernetes client.
     pub client: Client,
+    /// Operator settings.
+    pub settings: Settings,
 }
 
 /// Derive the CalibanTask status from the task + its backing Sandbox. Returns
@@ -67,19 +73,44 @@ fn status_eq(a: &CalibanTaskStatus, b: &CalibanTaskStatus) -> bool {
         && a.sandbox_ref.as_ref().map(|r| &r.name) == b.sandbox_ref.as_ref().map(|r| &r.name)
 }
 
+/// Server-side apply `obj` under `name`, force-owned by the operator's field
+/// manager. Used for the operator's own children (SA, NetworkPolicy, Sandbox).
+async fn apply<K>(api: &Api<K>, name: &str, obj: &K) -> Result<(), Error>
+where
+    K: Clone + std::fmt::Debug + serde::Serialize + serde::de::DeserializeOwned + Resource,
+    K::DynamicType: Default,
+{
+    let pp = PatchParams::apply("caliban-operator").force();
+    api.patch(name, &pp, &Patch::Apply(obj)).await?;
+    Ok(())
+}
+
 async fn reconcile(obj: Arc<CalibanTask>, ctx: Arc<Context>) -> Result<Action, Error> {
     let ns = obj.namespace().unwrap_or_default();
     let name = obj.name_any();
-    let api: Api<CalibanTask> = Api::namespaced(ctx.client.clone(), &ns);
+    let s = &ctx.settings;
+    let p = plan(&obj, s);
 
-    if let Some(status) = derive_status(&obj, None, &Settings::from_env()) {
+    // Apply children (idempotent SSA; owner refs cascade-delete).
+    let sa_api: Api<ServiceAccount> = Api::namespaced(ctx.client.clone(), &ns);
+    apply(&sa_api, &p.service_account.name_any(), &p.service_account).await?;
+    let np_api: Api<NetworkPolicy> = Api::namespaced(ctx.client.clone(), &ns);
+    apply(&np_api, &p.network_policy.name_any(), &p.network_policy).await?;
+    let sb_api: Api<Sandbox> = Api::namespaced(ctx.client.clone(), &ns);
+    apply(&sb_api, &p.sandbox.name_any(), &p.sandbox).await?;
+
+    // Read the Sandbox back for its status, then derive + patch CalibanTask status.
+    let sandbox = sb_api.get_opt(&sandbox_name(&obj)).await?;
+    if let Some(status) = derive_status(&obj, sandbox.as_ref(), s) {
+        let task_api: Api<CalibanTask> = Api::namespaced(ctx.client.clone(), &ns);
+        let phase = status.phase;
         let patch = serde_json::json!({ "status": status });
-        api.patch_status(&name, &PatchParams::default(), &Patch::Merge(&patch))
+        task_api
+            .patch_status(&name, &PatchParams::default(), &Patch::Merge(&patch))
             .await?;
-        tracing::info!(%ns, %name, "initialized CalibanTask status to Pending");
+        tracing::info!(%ns, %name, ?phase, "patched CalibanTask status");
     }
-    // #282 does nothing else; requeue on a slow cadence.
-    Ok(Action::requeue(Duration::from_secs(300)))
+    Ok(Action::requeue(Duration::from_secs(30)))
 }
 
 fn error_policy(_obj: Arc<CalibanTask>, err: &Error, _ctx: Arc<Context>) -> Action {
@@ -90,7 +121,10 @@ fn error_policy(_obj: Arc<CalibanTask>, err: &Error, _ctx: Arc<Context>) -> Acti
 /// Run the CalibanTask controller until shutdown.
 pub async fn run(client: Client) -> anyhow::Result<()> {
     let tasks: Api<CalibanTask> = Api::all(client.clone());
-    let ctx = Arc::new(Context { client });
+    let ctx = Arc::new(Context {
+        client,
+        settings: Settings::from_env(),
+    });
     Controller::new(tasks, Config::default())
         .run(reconcile, error_policy, ctx)
         .for_each(|res| async move {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -242,4 +242,17 @@ mod tests {
         assert!(d.sandbox_ref.is_none());
         assert!(d.caliband_endpoint.is_none());
     }
+
+    #[test]
+    fn cleared_endpoint_and_ref_serialize_as_null_for_merge_delete() {
+        // A status with a running endpoint, then cleared back to Pending.
+        let mut t = task_without_status();
+        let sb = sandbox_with_fqdn(Some("refactor-auth-sbx.team-a.svc"));
+        t.status = super::derive_status(&t, Some(&sb), &Settings::default());
+        let cleared = super::derive_status(&t, None, &Settings::default()).unwrap();
+        let v = serde_json::to_value(&cleared).unwrap();
+        // Merge-patch needs explicit null (not absent) to delete the stale values.
+        assert!(v.get("calibandEndpoint").is_some_and(|x| x.is_null()));
+        assert!(v.get("sandboxRef").is_some_and(|x| x.is_null()));
+    }
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -52,11 +52,9 @@ pub(crate) fn derive_status(
     let mut next = t.status.clone().unwrap_or_default();
     next.phase = phase;
     next.caliband_endpoint = endpoint;
-    if sandbox.is_some() {
-        next.sandbox_ref = Some(NamedRef {
-            name: sandbox_name(t),
-        });
-    }
+    next.sandbox_ref = sandbox.map(|_| NamedRef {
+        name: sandbox_name(t),
+    });
     match &t.status {
         Some(cur) if status_eq(cur, &next) => None,
         _ => Some(next),
@@ -195,5 +193,19 @@ mod tests {
         // First derivation, then apply it as the observed status.
         t.status = super::derive_status(&t, Some(&sb), &Settings::default());
         assert!(super::derive_status(&t, Some(&sb), &Settings::default()).is_none());
+    }
+
+    #[test]
+    fn sandbox_disappearing_clears_ref_and_returns_to_pending() {
+        let mut t = task_without_status();
+        let sb = sandbox_with_fqdn(Some("refactor-auth-sbx.team-a.svc"));
+        // Observed status reflects a running sandbox...
+        t.status = super::derive_status(&t, Some(&sb), &Settings::default());
+        assert!(t.status.as_ref().unwrap().sandbox_ref.is_some());
+        // ...then the sandbox is gone: status must return to Pending with no ref.
+        let d = super::derive_status(&t, None, &Settings::default()).unwrap();
+        assert_eq!(d.phase, Phase::Pending);
+        assert!(d.sandbox_ref.is_none());
+        assert!(d.caliband_endpoint.is_none());
     }
 }

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -143,10 +143,19 @@ pub struct CalibanTaskStatus {
     #[serde(default)]
     pub phase: Phase,
     /// caliband session endpoint (host:port), once the Sandbox is ready.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    // No `skip_serializing_if` here (unlike most optional status fields):
+    // `derive_status` transitions this back to `None` when the backing
+    // Sandbox disappears, and the status patch uses JSON Merge Patch
+    // (RFC 7396), where an *omitted* key is left unchanged on the server but
+    // an explicit `null` deletes it. Serializing `None` as `null` is required
+    // so a stale endpoint doesn't survive the merge. (`//` not `///` so this
+    // doesn't leak into the generated CRD schema description.)
+    #[serde(default)]
     pub caliband_endpoint: Option<String>,
     /// The agent-sandbox Sandbox backing this task.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    // See the note on `caliband_endpoint` above: no `skip_serializing_if`,
+    // for the same merge-patch-delete-via-null reason.
+    #[serde(default)]
     pub sandbox_ref: Option<NamedRef>,
     /// Latest checkpoint reference.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 //! resources into sandboxed caliband pods (via agent-sandbox). See ADR 0001 and
 //! the k8s system-design spec (epic caliban-ai/caliban#274).
 
+pub mod config;
 pub mod controller;
 pub mod crd;
 pub mod sandbox;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod config;
 pub mod controller;
 pub mod crd;
+pub mod resources;
 pub mod sandbox;
 
 pub use crd::{CalibanTask, CalibanTaskSpec, CalibanTaskStatus, Phase};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,5 +4,6 @@
 
 pub mod controller;
 pub mod crd;
+pub mod sandbox;
 
 pub use crd::{CalibanTask, CalibanTaskSpec, CalibanTaskStatus, Phase};

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -1,0 +1,144 @@
+//! Pure builders mapping a `CalibanTask` to the child objects a reconcile
+//! applies: a token-less ServiceAccount, a default-deny NetworkPolicy, and the
+//! backing agent-sandbox Sandbox. No cluster access — unit-tested. See ADR 0002.
+
+use std::collections::BTreeMap;
+
+use k8s_openapi::api::core::v1::ServiceAccount;
+use k8s_openapi::api::networking::v1::{
+    NetworkPolicy, NetworkPolicyEgressRule, NetworkPolicyIngressRule, NetworkPolicyPort,
+    NetworkPolicySpec,
+};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
+use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
+use kube::ResourceExt;
+
+use crate::config::{common_labels, netpol_name, owner_ref, sa_name, Settings};
+use crate::crd::CalibanTask;
+
+fn child_meta(t: &CalibanTask, name: String, labels: BTreeMap<String, String>) -> ObjectMeta {
+    ObjectMeta {
+        name: Some(name),
+        namespace: t.namespace(),
+        labels: Some(labels),
+        owner_references: Some(vec![owner_ref(t)]),
+        ..Default::default()
+    }
+}
+
+/// A dedicated, token-less ServiceAccount — the pod's least-privilege identity.
+pub fn build_service_account(t: &CalibanTask) -> ServiceAccount {
+    ServiceAccount {
+        metadata: child_meta(t, sa_name(t), common_labels(t)),
+        automount_service_account_token: Some(false),
+        ..Default::default()
+    }
+}
+
+fn np_port(proto: &str, port: i32) -> NetworkPolicyPort {
+    NetworkPolicyPort {
+        protocol: Some(proto.to_string()),
+        port: Some(IntOrString::Int(port)),
+        ..Default::default()
+    }
+}
+
+/// Default-deny NetworkPolicy: allow DNS + general egress + caliband-port ingress.
+pub fn build_network_policy(t: &CalibanTask, s: &Settings) -> NetworkPolicy {
+    NetworkPolicy {
+        metadata: child_meta(t, netpol_name(t), common_labels(t)),
+        spec: Some(NetworkPolicySpec {
+            // Select the sandbox pod by the labels we propagate into its template.
+            pod_selector: Some(LabelSelector {
+                match_labels: Some(common_labels(t)),
+                ..Default::default()
+            }),
+            policy_types: Some(vec!["Ingress".to_string(), "Egress".to_string()]),
+            // Ingress: caliband port only.
+            ingress: Some(vec![NetworkPolicyIngressRule {
+                ports: Some(vec![np_port("TCP", s.caliband_port)]),
+                ..Default::default()
+            }]),
+            // Egress: DNS (53 UDP+TCP), then everything else (git/providers).
+            egress: Some(vec![
+                NetworkPolicyEgressRule {
+                    ports: Some(vec![np_port("UDP", 53), np_port("TCP", 53)]),
+                    ..Default::default()
+                },
+                NetworkPolicyEgressRule::default(),
+            ]),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crd::{CalibanTaskSpec, Source, TaskSpec, Workspace};
+
+    fn task() -> CalibanTask {
+        let mut t = CalibanTask::new(
+            "refactor-auth",
+            CalibanTaskSpec {
+                workspace: Workspace {
+                    sources: vec![Source {
+                        name: "caliban".into(),
+                        repo: "git@x:caliban".into(),
+                        r#ref: "main".into(),
+                        path: "/work/caliban".into(),
+                    }],
+                    services: vec![],
+                },
+                task: TaskSpec {
+                    prompt: "hi".into(),
+                    agent_type: None,
+                },
+                model: None,
+                state: None,
+                isolation: None,
+                resources: None,
+                lifecycle: None,
+            },
+        );
+        t.metadata.namespace = Some("team-a".into());
+        t.metadata.uid = Some("uid-123".into());
+        t
+    }
+
+    #[test]
+    fn service_account_is_token_less_and_owned() {
+        let sa = build_service_account(&task());
+        assert_eq!(sa.metadata.name.as_deref(), Some("refactor-auth-sa"));
+        assert_eq!(sa.metadata.namespace.as_deref(), Some("team-a"));
+        assert_eq!(sa.automount_service_account_token, Some(false));
+        let owners = sa.metadata.owner_references.unwrap();
+        assert_eq!(owners[0].controller, Some(true));
+        assert_eq!(owners[0].kind, "CalibanTask");
+    }
+
+    #[test]
+    fn network_policy_is_default_deny_with_dns_and_caliband_ingress() {
+        let np = build_network_policy(&task(), &Settings::default());
+        let spec = np.spec.unwrap();
+        assert_eq!(
+            spec.policy_types.as_ref().unwrap(),
+            &vec!["Ingress".to_string(), "Egress".to_string()]
+        );
+        // Ingress allows the caliband port.
+        let iports = spec.ingress.unwrap()[0].ports.clone().unwrap();
+        assert!(iports
+            .iter()
+            .any(|p| p.port == Some(IntOrString::Int(8443))));
+        // Egress: DNS rule + an allow-all rule (empty `to`).
+        let egress = spec.egress.unwrap();
+        assert_eq!(egress.len(), 2);
+        assert!(egress[1].to.is_none()); // allow-all destinations
+                                         // Selects the pod by our managed labels.
+        assert!(spec
+            .pod_selector
+            .unwrap()
+            .match_labels
+            .unwrap()
+            .contains_key("caliban.caliban-ai.dev/task"));
+    }
+}

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -110,8 +110,7 @@ fn caliband_env(t: &CalibanTask, s: &Settings) -> Vec<EnvVar> {
     e
 }
 
-fn workspace_pvc(t: &CalibanTask, s: &Settings) -> PersistentVolumeClaim {
-    let _ = t;
+fn workspace_pvc(s: &Settings) -> PersistentVolumeClaim {
     PersistentVolumeClaim {
         metadata: ObjectMeta {
             name: Some(WORKSPACE_VOLUME.to_string()),
@@ -175,7 +174,7 @@ pub fn build_sandbox(t: &CalibanTask, s: &Settings) -> Sandbox {
             },
             service: Some(true),
             operating_mode: Some("Running".to_string()),
-            volume_claim_templates: Some(vec![workspace_pvc(t, s)]),
+            volume_claim_templates: Some(vec![workspace_pvc(s)]),
         },
     );
     sb.metadata.namespace = t.namespace();

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -4,17 +4,22 @@
 
 use std::collections::BTreeMap;
 
-use k8s_openapi::api::core::v1::ServiceAccount;
+use k8s_openapi::api::core::v1::{
+    Container, ContainerPort, EnvVar, PersistentVolumeClaim, PersistentVolumeClaimSpec, PodSpec,
+    PodTemplateSpec, ServiceAccount, VolumeMount, VolumeResourceRequirements,
+};
 use k8s_openapi::api::networking::v1::{
     NetworkPolicy, NetworkPolicyEgressRule, NetworkPolicyIngressRule, NetworkPolicyPeer,
     NetworkPolicyPort, NetworkPolicySpec,
 };
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
 use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 use kube::ResourceExt;
 
-use crate::config::{common_labels, netpol_name, owner_ref, sa_name, Settings};
+use crate::config::{common_labels, netpol_name, owner_ref, sa_name, sandbox_name, Settings};
 use crate::crd::CalibanTask;
+use crate::sandbox::{Sandbox, SandboxSpec};
 
 fn child_meta(t: &CalibanTask, name: String, labels: BTreeMap<String, String>) -> ObjectMeta {
     ObjectMeta {
@@ -72,6 +77,111 @@ pub fn build_network_policy(t: &CalibanTask, s: &Settings) -> NetworkPolicy {
             ]),
         }),
     }
+}
+
+const WORKSPACE_VOLUME: &str = "workspace";
+
+fn env(name: &str, value: String) -> EnvVar {
+    EnvVar {
+        name: name.to_string(),
+        value: Some(value),
+        ..Default::default()
+    }
+}
+
+fn caliband_env(t: &CalibanTask, s: &Settings) -> Vec<EnvVar> {
+    let sources = serde_json::to_string(&t.spec.workspace.sources).unwrap_or_else(|_| "[]".into());
+    let mut e = vec![
+        env(
+            "CALIBAND_LISTEN",
+            format!("tcp://0.0.0.0:{}", s.caliband_port),
+        ),
+        env("CALIBAN_WORKSPACE_ROOT", s.workspace_root.clone()),
+        env("CALIBAN_WORKSPACE_SOURCES", sources),
+    ];
+    if let Some(ep) = t
+        .spec
+        .state
+        .as_ref()
+        .and_then(|st| st.gonzalo_endpoint.clone())
+    {
+        e.push(env("GONZALO_ENDPOINT", ep));
+    }
+    e
+}
+
+fn workspace_pvc(t: &CalibanTask, s: &Settings) -> PersistentVolumeClaim {
+    let _ = t;
+    PersistentVolumeClaim {
+        metadata: ObjectMeta {
+            name: Some(WORKSPACE_VOLUME.to_string()),
+            ..Default::default()
+        },
+        spec: Some(PersistentVolumeClaimSpec {
+            access_modes: Some(vec!["ReadWriteOnce".to_string()]),
+            resources: Some(VolumeResourceRequirements {
+                requests: Some(BTreeMap::from([(
+                    "storage".to_string(),
+                    Quantity(s.workspace_storage.clone()),
+                )])),
+                ..Default::default()
+            }),
+            // storageClassName unset → cluster default (cluster-agnostic).
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+/// Map a `CalibanTask` to its backing agent-sandbox `Sandbox`.
+pub fn build_sandbox(t: &CalibanTask, s: &Settings) -> Sandbox {
+    let labels = common_labels(t);
+    let container = Container {
+        name: "caliband".to_string(),
+        image: Some(s.caliband_image.clone()),
+        ports: Some(vec![ContainerPort {
+            container_port: s.caliband_port,
+            name: Some("caliband".to_string()),
+            ..Default::default()
+        }]),
+        env: Some(caliband_env(t, s)),
+        volume_mounts: Some(vec![VolumeMount {
+            name: WORKSPACE_VOLUME.to_string(),
+            mount_path: s.workspace_root.clone(),
+            ..Default::default()
+        }]),
+        ..Default::default()
+    };
+    let pod_spec = PodSpec {
+        containers: vec![container],
+        runtime_class_name: t
+            .spec
+            .isolation
+            .as_ref()
+            .and_then(|i| i.runtime_class.clone()),
+        service_account_name: Some(sa_name(t)),
+        automount_service_account_token: Some(false),
+        ..Default::default()
+    };
+    let mut sb = Sandbox::new(
+        &sandbox_name(t),
+        SandboxSpec {
+            pod_template: PodTemplateSpec {
+                metadata: Some(ObjectMeta {
+                    labels: Some(labels.clone()),
+                    ..Default::default()
+                }),
+                spec: Some(pod_spec),
+            },
+            service: Some(true),
+            operating_mode: Some("Running".to_string()),
+            volume_claim_templates: Some(vec![workspace_pvc(t, s)]),
+        },
+    );
+    sb.metadata.namespace = t.namespace();
+    sb.metadata.labels = Some(labels);
+    sb.metadata.owner_references = Some(vec![owner_ref(t)]);
+    sb
 }
 
 #[cfg(test)]
@@ -149,5 +259,64 @@ mod tests {
             .match_labels
             .unwrap()
             .contains_key("caliban.caliban-ai.dev/task"));
+    }
+
+    #[test]
+    fn sandbox_has_caliband_container_pvc_and_service() {
+        let s = Settings::default();
+        let sb = build_sandbox(&task(), &s);
+        assert_eq!(sb.metadata.name.as_deref(), Some("refactor-auth-sbx"));
+        assert_eq!(sb.metadata.namespace.as_deref(), Some("team-a"));
+        assert_eq!(sb.spec.service, Some(true));
+        let pod = sb.spec.pod_template.spec.unwrap();
+        assert_eq!(
+            pod.service_account_name.as_deref(),
+            Some("refactor-auth-sa")
+        );
+        assert_eq!(pod.automount_service_account_token, Some(false));
+        let c = &pod.containers[0];
+        assert_eq!(
+            c.image.as_deref(),
+            Some("ghcr.io/caliban-ai/caliban:latest")
+        );
+        assert_eq!(c.ports.as_ref().unwrap()[0].container_port, 8443);
+        // Env projects the listen addr + workspace root.
+        let env = c.env.as_ref().unwrap();
+        assert!(env.iter().any(
+            |e| e.name == "CALIBAND_LISTEN" && e.value.as_deref() == Some("tcp://0.0.0.0:8443")
+        ));
+        assert!(env.iter().any(|e| e.name == "CALIBAN_WORKSPACE_ROOT"));
+        // Workspace PVC present.
+        let pvcs = sb.spec.volume_claim_templates.unwrap();
+        assert_eq!(pvcs[0].metadata.name.as_deref(), Some("workspace"));
+        // Pod carries the managed labels (so the NetworkPolicy selects it).
+        assert!(sb
+            .spec
+            .pod_template
+            .metadata
+            .unwrap()
+            .labels
+            .unwrap()
+            .contains_key("caliban.caliban-ai.dev/task"));
+    }
+
+    #[test]
+    fn sandbox_runtime_class_from_isolation() {
+        use crate::crd::IsolationSpec;
+        let mut t = task();
+        t.spec.isolation = Some(IsolationSpec {
+            runtime_class: Some("gvisor".into()),
+            worktrees: None,
+        });
+        let sb = build_sandbox(&t, &Settings::default());
+        assert_eq!(
+            sb.spec
+                .pod_template
+                .spec
+                .unwrap()
+                .runtime_class_name
+                .as_deref(),
+            Some("gvisor")
+        );
     }
 }

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -107,6 +107,14 @@ fn caliband_env(t: &CalibanTask, s: &Settings) -> Vec<EnvVar> {
     {
         e.push(env("GONZALO_ENDPOINT", ep));
     }
+    if let Some(r) = t
+        .spec
+        .model
+        .as_ref()
+        .and_then(|m| m.router_config_ref.clone())
+    {
+        e.push(env("CALIBAN_ROUTER_CONFIG_REF", r));
+    }
     e
 }
 
@@ -304,6 +312,8 @@ mod tests {
             |e| e.name == "CALIBAND_LISTEN" && e.value.as_deref() == Some("tcp://0.0.0.0:8443")
         ));
         assert!(env.iter().any(|e| e.name == "CALIBAN_WORKSPACE_ROOT"));
+        // No model configured in the default fixture → no router-config env.
+        assert!(!env.iter().any(|e| e.name == "CALIBAN_ROUTER_CONFIG_REF"));
         // Workspace PVC present.
         let pvcs = sb.spec.volume_claim_templates.unwrap();
         assert_eq!(pvcs[0].metadata.name.as_deref(), Some("workspace"));
@@ -336,6 +346,20 @@ mod tests {
                 .as_deref(),
             Some("gvisor")
         );
+    }
+
+    #[test]
+    fn sandbox_projects_router_config_ref_env_when_model_set() {
+        use crate::crd::ModelSpec;
+        let mut t = task();
+        t.spec.model = Some(ModelSpec {
+            router_config_ref: Some("caliban-router".into()),
+        });
+        let sb = build_sandbox(&t, &Settings::default());
+        let pod = sb.spec.pod_template.spec.unwrap();
+        let env = pod.containers[0].env.as_ref().unwrap();
+        assert!(env.iter().any(|e| e.name == "CALIBAN_ROUTER_CONFIG_REF"
+            && e.value.as_deref() == Some("caliban-router")));
     }
 
     #[test]

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -183,6 +183,25 @@ pub fn build_sandbox(t: &CalibanTask, s: &Settings) -> Sandbox {
     sb
 }
 
+/// The child objects a single reconcile applies.
+pub struct ReconcilePlan {
+    /// The task's dedicated, token-less ServiceAccount.
+    pub service_account: ServiceAccount,
+    /// The default-deny NetworkPolicy scoping the sandbox pod's traffic.
+    pub network_policy: NetworkPolicy,
+    /// The backing agent-sandbox Sandbox.
+    pub sandbox: Sandbox,
+}
+
+/// Assemble every child object for a task (pure).
+pub fn plan(t: &CalibanTask, s: &Settings) -> ReconcilePlan {
+    ReconcilePlan {
+        service_account: build_service_account(t),
+        network_policy: build_network_policy(t, s),
+        sandbox: build_sandbox(t, s),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -316,6 +335,23 @@ mod tests {
                 .runtime_class_name
                 .as_deref(),
             Some("gvisor")
+        );
+    }
+
+    #[test]
+    fn plan_names_all_three_children() {
+        let p = plan(&task(), &Settings::default());
+        assert_eq!(
+            p.service_account.metadata.name.as_deref(),
+            Some("refactor-auth-sa")
+        );
+        assert_eq!(
+            p.network_policy.metadata.name.as_deref(),
+            Some("refactor-auth-netpol")
+        );
+        assert_eq!(
+            p.sandbox.metadata.name.as_deref(),
+            Some("refactor-auth-sbx")
         );
     }
 }

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -6,8 +6,8 @@ use std::collections::BTreeMap;
 
 use k8s_openapi::api::core::v1::ServiceAccount;
 use k8s_openapi::api::networking::v1::{
-    NetworkPolicy, NetworkPolicyEgressRule, NetworkPolicyIngressRule, NetworkPolicyPort,
-    NetworkPolicySpec,
+    NetworkPolicy, NetworkPolicyEgressRule, NetworkPolicyIngressRule, NetworkPolicyPeer,
+    NetworkPolicyPort, NetworkPolicySpec,
 };
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
 use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
@@ -57,7 +57,10 @@ pub fn build_network_policy(t: &CalibanTask, s: &Settings) -> NetworkPolicy {
             // Ingress: caliband port only.
             ingress: Some(vec![NetworkPolicyIngressRule {
                 ports: Some(vec![np_port("TCP", s.caliband_port)]),
-                ..Default::default()
+                from: Some(vec![NetworkPolicyPeer {
+                    pod_selector: Some(LabelSelector::default()),
+                    ..Default::default()
+                }]),
             }]),
             // Egress: DNS (53 UDP+TCP), then everything else (git/providers).
             egress: Some(vec![
@@ -125,10 +128,16 @@ mod tests {
             &vec!["Ingress".to_string(), "Egress".to_string()]
         );
         // Ingress allows the caliband port.
-        let iports = spec.ingress.unwrap()[0].ports.clone().unwrap();
+        let ingress = spec.ingress.unwrap();
+        let iports = ingress[0].ports.clone().unwrap();
         assert!(iports
             .iter()
             .any(|p| p.port == Some(IntOrString::Int(8443))));
+        // Ingress is scoped to the task's own namespace (same-namespace peer).
+        let peers = ingress[0].from.clone().unwrap();
+        assert_eq!(peers.len(), 1);
+        assert!(peers[0].pod_selector.is_some());
+        assert!(peers[0].namespace_selector.is_none());
         // Egress: DNS rule + an allow-all rule (empty `to`).
         let egress = spec.egress.unwrap();
         assert_eq!(egress.len(), 2);

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,0 +1,78 @@
+//! A minimal foreign view of agent-sandbox's `Sandbox` CRD
+//! (`agents.x-k8s.io/v1beta1`). We consume it — we declare only the fields the
+//! operator sets or reads; the API server prunes the rest. We never emit this
+//! CRD (agent-sandbox owns it), so `Sandbox::crd()` is intentionally unused. See
+//! ADR 0002.
+
+use k8s_openapi::api::core::v1::{PersistentVolumeClaim, PodTemplateSpec};
+use kube::CustomResource;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Desired state of an agent-sandbox `Sandbox` (subset the operator manages).
+#[derive(CustomResource, Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[kube(
+    group = "agents.x-k8s.io",
+    version = "v1beta1",
+    kind = "Sandbox",
+    namespaced,
+    status = "SandboxStatus"
+)]
+#[serde(rename_all = "camelCase")]
+pub struct SandboxSpec {
+    /// Pod template for the sandbox's single pod.
+    pub pod_template: PodTemplateSpec,
+    /// Provision a headless Service (→ stable `serviceFQDN`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service: Option<bool>,
+    /// `Running` or `Suspended`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub operating_mode: Option<String>,
+    /// PVCs materialized for the sandbox (persist across restarts).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub volume_claim_templates: Option<Vec<PersistentVolumeClaim>>,
+}
+
+/// Observed state of a `Sandbox` (subset the operator reads).
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SandboxStatus {
+    /// Stable in-cluster DNS name for the sandbox's Service.
+    #[serde(
+        default,
+        rename = "serviceFQDN",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub service_fqdn: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sandbox_serializes_with_group_version_kind() {
+        let sb = Sandbox::new(
+            "demo-sbx",
+            SandboxSpec {
+                pod_template: PodTemplateSpec::default(),
+                service: Some(true),
+                operating_mode: Some("Running".to_string()),
+                volume_claim_templates: None,
+            },
+        );
+        let v = serde_json::to_value(&sb).unwrap();
+        assert_eq!(v["apiVersion"], "agents.x-k8s.io/v1beta1");
+        assert_eq!(v["kind"], "Sandbox");
+        assert_eq!(v["spec"]["service"], true);
+        assert_eq!(v["spec"]["operatingMode"], "Running");
+        assert!(v["spec"]["podTemplate"].is_object());
+    }
+
+    #[test]
+    fn status_reads_service_fqdn() {
+        let json = serde_json::json!({ "serviceFQDN": "demo-sbx.team-a.svc" });
+        let st: SandboxStatus = serde_json::from_value(json).unwrap();
+        assert_eq!(st.service_fqdn.as_deref(), Some("demo-sbx.team-a.svc"));
+    }
+}


### PR DESCRIPTION
## What

Makes the operator's reconcile real: a `CalibanTask` is now turned into a running, sandboxed caliband pod reachable at a stable DNS, with a per-task token-less ServiceAccount and a default-deny NetworkPolicy, and `.status` (phase + `calibandEndpoint`) is driven from the backing agent-sandbox `Sandbox`.

Closes caliban-ai/caliban#283. Part of the k8s epic caliban-ai/caliban#274 (P2). Builds on #282 (CRD scaffold). Design: ADR 0002 (`docs/adr/0002-reconcile-calibantask-to-sandbox.md`) + plan (`docs/plans/2026-07-04-p2-reconcile-sandbox.md`).

## How

Reconcile = **pure builders + a thin apply loop**:

- **Foreign `Sandbox` type** (`src/sandbox.rs`) — a minimal hand-authored view of agent-sandbox's `agents.x-k8s.io/v1beta1` `Sandbox` (we consume it; we never emit/drift-guard its CRD). The `serviceFQDN` wire key is preserved exactly (acronym casing).
- **Pure builders** (`src/resources.rs`) — `build_sandbox` (caliband container: image/port/env, workspace PVC via `volumeClaimTemplates`, runtimeClass from `spec.isolation`, token-less SA ref, `service: true`), `build_service_account` (token-less, no bound Role = zero API rights), `build_network_policy` (default-deny; DNS + general egress; caliband-port ingress scoped to the task namespace). All unit-tested, no cluster.
- **Status derivation** (`src/controller.rs`) — `derive_status` maps the Sandbox's `serviceFQDN` presence to `Pending → Provisioning → Running` with `calibandEndpoint = "<serviceFQDN>:8443"` + `sandboxRef`; no-op churn avoidance; clears stale fields on merge-patch (`null`).
- **Async reconcile** — server-side-applies the three children (owner-referenced for GC), reads the Sandbox back (`get_opt`), patches `CalibanTask.status`.

Every child carries a controller `OwnerReference` and the same `common_labels`, so the NetworkPolicy `podSelector` matches the Sandbox pod and deletion cascades.

## Scope / deferrals (ADR 0002 §7)

Deferred (absent, not half-built): the caliban-aware drain finalizer (needs caliband checkpoint gRPC, #314), idle→pause/resume, `SandboxTemplate`/warm pools (Phase 4), full Secret/ConfigMap credential projection. The operator's own cluster RBAC ships with the operator chart (#284).

## Test / QA

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo build --workspace --all-targets`, `cargo test --workspace` (**21 passing**) — all green.
- `crdgen` output is byte-identical to the committed CalibanTask CRD (the `Sandbox` CRD is never emitted).
- **QA-gate follow-up:** confirm agent-sandbox v0.5.0 propagates `podTemplate.metadata.labels` onto the pod (standard controller behavior) so the default-deny NetworkPolicy selects it — verify in the home-cluster round.

Built subagent-driven (implement → per-task review → whole-branch review on the most capable model). The final review caught and fixed a merge-patch stale-field bug (I1) before merge.
