### PR TITLE
feat(ci-cd): caliban-operator container image + multi-arch release workflow (#358)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Build artifacts and VCS — never needed in the image context.
+target/
+.git/
+.github/
+.claude/
+
+# Docs / metadata not needed to build the binary.
+docs/
+*.md
+CODEOWNERS
+
+# Editor / OS junk.
+Cargo.lock.bak
+*.swp
+*.rs.bk
+.DS_Store

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,99 @@
+name: release-image
+on:
+  pull_request:
+    paths: ["Dockerfile", ".dockerignore", "Cargo.toml", "Cargo.lock", "rust-toolchain.toml", "src/**", ".github/workflows/release-image.yml"]
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+concurrency:
+  group: release-image-${{ github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+  packages: write
+env:
+  IMAGE: ghcr.io/caliban-ai/caliban-operator
+jobs:
+  # Build each architecture on its own NATIVE runner (no QEMU): amd64 on
+  # ubuntu-latest, arm64 on ubuntu-24.04-arm (free for public repos). On PRs both
+  # arches build with no push (validation); on tags/dispatch each pushes by digest
+  # and the merge job assembles the multi-arch manifest.
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build (validate on PR, push-by-digest on release)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          outputs: ${{ github.event_name != 'pull_request' && format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.IMAGE) || 'type=cacheonly' }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.platform == 'linux/arm64' && 'arm64' || 'amd64' }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+  # Assemble the multi-arch manifest list from the per-arch digests and push the
+  # semver / sha tags. Tag/dispatch only.
+  merge:
+    if: github.event_name != 'pull_request'
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      - uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha,prefix=sha-
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+      - name: Inspect
+        run: docker buildx imagetools inspect ${{ env.IMAGE }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1
+
+# ---- builder ----
+FROM rust:1.95-bookworm AS builder
+WORKDIR /src
+# rustls (ring) + kube; no openssl/protoc/git2 native deps, so the base image's
+# toolchain is sufficient — no extra apt.
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo build --release --bin caliban-operator
+
+# ---- runtime ----
+FROM debian:bookworm-slim AS runtime
+# ca-certificates so the kube client can verify TLS (and openssl-probe can find
+# the system trust store). The operator writes nothing to disk — it is a
+# controller — so it runs happily under a read-only root filesystem.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+# Non-root user matching the chart's securityContext (runAsUser 10001).
+RUN useradd --uid 10001 --create-home --home-dir /home/app --shell /usr/sbin/nologin app
+COPY --from=builder /src/target/release/caliban-operator /usr/local/bin/caliban-operator
+USER 10001
+WORKDIR /home/app
+# Runs the controller (watch CalibanTasks + reconcile). Config is via env
+# (RUST_LOG, CALIBAND_IMAGE, CALIBAND_PORT, CALIBAN_WORKSPACE_*) — see the chart.
+ENTRYPOINT ["caliban-operator"]

--- a/docs/container.md
+++ b/docs/container.md
@@ -1,0 +1,44 @@
+# caliban-operator container image
+
+The operator ships as a multi-arch container image at
+**`ghcr.io/caliban-ai/caliban-operator`** (linux/amd64 + linux/arm64).
+
+## What's in it
+
+A two-stage build (`Dockerfile`):
+
+- **builder** — `rust:1.95-bookworm`, `cargo build --release --bin caliban-operator`
+  (rustls/ring + kube; no openssl/protoc/git2 native deps).
+- **runtime** — `debian:bookworm-slim` + `ca-certificates`, running the
+  `caliban-operator` controller binary as a **non-root** user (uid `10001`,
+  matching the Helm chart's `securityContext`). The operator writes nothing to
+  disk, so it runs fine under a **read-only root filesystem**.
+
+The image contains only the controller (`caliban-operator`), not the `crdgen`
+dev tool. Configuration is entirely via environment (`RUST_LOG`, `CALIBAND_IMAGE`,
+`CALIBAND_PORT`, `CALIBAN_WORKSPACE_ROOT`, `CALIBAN_WORKSPACE_STORAGE`) — see the
+`caliban-operator` Helm chart.
+
+## Build locally
+
+```sh
+docker build -t caliban-operator:dev .
+```
+
+## Publishing (CI)
+
+`.github/workflows/release-image.yml` mirrors the sibling repos' **native
+per-arch** pipeline (no QEMU):
+
+- **Pull requests** touching the build inputs build **both** arches on native
+  runners (amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm`) with **no push**
+  — pure validation.
+- **`v*` tags** (and `workflow_dispatch`) build each arch, push it **by digest**,
+  then a `merge` job assembles the multi-arch manifest list and pushes the
+  `{{version}}` and `sha-<sha>` tags via `docker buildx imagetools create`.
+
+Cut a release by tagging:
+
+```sh
+git tag v0.1.0 && git push origin v0.1.0
+```


### PR DESCRIPTION
## What

Give the caliban-operator a **container image** so it can actually be deployed. Closes caliban-ai/caliban#358. Unblocks the home-cluster install of the operator MVP (#283/#284) — the `caliban-operator` Helm chart references `ghcr.io/caliban-ai/caliban-operator`, which nothing built until now.

## How

- **`Dockerfile`** — two-stage: `rust:1.95-bookworm` builds `--release --bin caliban-operator` (rustls/ring + kube; no openssl/protoc/git2 native deps); `debian:bookworm-slim` + `ca-certificates` runtime running the controller as **non-root uid 10001** (matches the chart's `securityContext`). The operator writes nothing to disk → runs under a **read-only root filesystem**. Only the controller ships (not the `crdgen` dev tool).
- **`.dockerignore`** — excludes `target/`, `.git/`, `.claude/`, `.github/`, docs.
- **`.github/workflows/release-image.yml`** — mirrors the sibling repos' **native per-arch** pipeline (no QEMU): amd64 on `ubuntu-latest` + arm64 on `ubuntu-24.04-arm`; PRs build both arches with **no push** (validation), `v*` tags push-by-digest + `imagetools create` merge → multi-arch `ghcr.io/caliban-ai/caliban-operator`.
- **`docs/container.md`**.

## Verified locally

- `docker build` succeeds (release binary, ~50s build).
- `docker run` as **uid 10001** under `--read-only`: the controller starts and fails gracefully inferring kube config (no cluster reachable from a bare container — in-cluster it uses the mounted service-account CA). Image ~119MB.
- This PR's `release-image` workflow builds both arches (no push) as the CI validation.

## Follow-up

To actually publish: cut a `v*` tag on caliban-operator (exercises the multi-arch GHCR push + arm64 build), then set the chart's `image.tag`.
