### PR TITLE
fix(operator): make the Sandbox actually launch caliband (daemon args + workspace init) (#366)

### DIFF
--- a/docs/adr/0003-caliband-launch-contract.md
+++ b/docs/adr/0003-caliband-launch-contract.md
@@ -66,3 +66,6 @@ the caliban image's Dockerfile:
   (`serviceFQDN:<port>`) works; per-agent attach dialing from outside the pod (prospero's
   session plane) needs `--advertise-host <serviceFQDN>` + per-agent port routing — a
   follow-up paired with prospero #77.
+- **`git clone --depth 1 --branch <ref>` accepts branch/tag names only, not commit
+  SHAs** — a `ref` set to a raw commit SHA will fail the clone (the CRD's `ref` defaults
+  to `main`; SHA-pinning is a follow-up).

--- a/docs/adr/0003-caliband-launch-contract.md
+++ b/docs/adr/0003-caliband-launch-contract.md
@@ -1,0 +1,68 @@
+# ADR 0003 · The caliband launch contract (daemon args + workspace init)
+
+- **Status:** accepted
+- **Date:** 2026-07-05
+- **Source:** caliban [#366](https://github.com/caliban-ai/caliban/issues/366) (follow-up to [#283](https://github.com/caliban-ai/caliban/issues/283)) · epic [#274](https://github.com/caliban-ai/caliban/issues/274) · builds on [ADR 0002](0002-reconcile-calibantask-to-sandbox.md)
+
+## Context
+
+[ADR 0002](0002-reconcile-calibantask-to-sandbox.md) reconciled a `CalibanTask` into a
+correctly-shaped `Sandbox`/SA/NetworkPolicy but explicitly deferred the exact caliband
+container contract ("the exact caliband env contract isn't built yet"). A home-cluster
+dry run exposed that the deferred contract is load-bearing: **the pod as built by #283
+would not run a live caliband.** Verified against caliban's `caliband.rs` arg parser and
+the caliban image's Dockerfile:
+
+- The image is `ENTRYPOINT ["caliband"]`, `CMD ["--help"]`. #283 set no container
+  `command`/`args`, so the pod runs **`caliband --help` → prints usage → exits →
+  CrashLoop**.
+- caliband takes `--workspace-root <path>` as a **required flag** (there is no env for
+  it); #283 set `CALIBAN_WORKSPACE_ROOT` env, which caliband ignores.
+- The network switch is `--listen <host:port>` (or `CALIBAN_DAEMON_LISTEN`, format
+  `host:port`); #283 set `CALIBAND_LISTEN=tcp://…` — wrong name and wrong format.
+- `CALIBAN_WORKSPACE_SOURCES` (an invented env) is read by nothing, and **no one clones
+  the workspace sources into the `/work` PVC**, so the workspace is empty.
+- caliband's `--tls-cert/--tls-key/--token` are **optional**, so `--listen` without them
+  is valid **plaintext TCP**.
+
+## Decision
+
+1. **Run caliband as a daemon via container `args`.** `build_sandbox` sets the caliband
+   container's `args` to `["--workspace-root", <workspace_root>, "--listen",
+   "0.0.0.0:<caliband_port>"]`, replacing the image's `--help` CMD (the `caliband`
+   ENTRYPOINT is kept). This uses only flags caliband actually parses.
+
+2. **Drop the mismatched env.** Remove `CALIBAND_LISTEN`, `CALIBAN_WORKSPACE_ROOT`, and
+   `CALIBAN_WORKSPACE_SOURCES` (none are read; listen + root are now flags, sources are
+   handled by the init container). Keep `GONZALO_ENDPOINT` / `CALIBAN_ROUTER_CONFIG_REF`
+   (consumed by the caliban agent runtime, harmless if unset).
+
+3. **Populate the workspace with a git-clone init container.** Add an init container
+   (image from a new `git_image` setting, default a public `alpine/git`) that mounts the
+   workspace volume and, for each `spec.workspace.sources[]`, clones `repo` at `ref` into
+   `path` — idempotently (skip if `<path>/.git` already exists, so pause/resume and pod
+   restarts over the persistent PVC don't refetch or fail). Public sources only for now;
+   private-source auth is a follow-up.
+
+4. **Plaintext TCP for the first e2e.** The operator runs caliband with `--listen` and
+   **no TLS/token**. This is sufficient to prove the pipeline (a reachable caliband on the
+   Sandbox DNS) and matches caliban's optional-TLS design. Provisioning per-Sandbox certs
+   + a bearer token (and wiring prospero's matching client) is a tracked security
+   follow-up — the transport already supports it (caliban #280).
+
+## Consequences
+
+- **Applying a `CalibanTask` now yields a caliband that actually starts, has its workspace
+  cloned, and listens** on the Sandbox endpoint — closing the gap between "objects render"
+  and "an agent can run". This unblocks the home-cluster e2e.
+- **Plaintext TCP is a deliberate, temporary posture.** The default-deny NetworkPolicy
+  (ADR 0002) still constrains who can reach the port, but the control/stream bytes are
+  unencrypted and unauthenticated until the TLS/token follow-up lands. Not for
+  multi-tenant/production use.
+- **The init container needs a git image and egress** to clone sources — the ADR 0002
+  NetworkPolicy already allows general egress. Private sources will need credential
+  projection (deferred).
+- **`advertise-host` / per-agent ports are not yet set.** Control-plane reachability
+  (`serviceFQDN:<port>`) works; per-agent attach dialing from outside the pod (prospero's
+  session plane) needs `--advertise-host <serviceFQDN>` + per-agent port routing — a
+  follow-up paired with prospero #77.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,3 +11,4 @@ history.
 | [0000](0000-architecture-decision-records.md) | Record architecture decisions (MADR-lite under `docs/adr/`) | accepted |
 | [0001](0001-kube-rs-stack-and-calibantask-crd.md) | kube-rs stack + `CalibanTask` CRD API (`caliban.caliban-ai.dev/v1alpha1`, namespaced, status subresource; generated CRD YAML) | accepted |
 | [0002](0002-reconcile-calibantask-to-sandbox.md) | Reconcile `CalibanTask` → agent-sandbox `Sandbox` (+ per-task token-less SA & default-deny NetworkPolicy; foreign `Sandbox` type; SSA + owner refs; status from `serviceFQDN`) | accepted |
+| [0003](0003-caliband-launch-contract.md) | The caliband launch contract — daemon `args` (`--workspace-root`/`--listen`), git-clone init container for the workspace, plaintext TCP for the first e2e | accepted |

--- a/docs/container.md
+++ b/docs/container.md
@@ -16,8 +16,8 @@ A two-stage build (`Dockerfile`):
 
 The image contains only the controller (`caliban-operator`), not the `crdgen`
 dev tool. Configuration is entirely via environment (`RUST_LOG`, `CALIBAND_IMAGE`,
-`CALIBAND_PORT`, `CALIBAN_WORKSPACE_ROOT`, `CALIBAN_WORKSPACE_STORAGE`) — see the
-`caliban-operator` Helm chart.
+`CALIBAND_PORT`, `CALIBAN_WORKSPACE_ROOT`, `CALIBAN_WORKSPACE_STORAGE`,
+`CALIBAN_GIT_IMAGE`) — see the `caliban-operator` Helm chart.
 
 ## Build locally
 

--- a/docs/plans/2026-07-05-caliband-launch-contract.md
+++ b/docs/plans/2026-07-05-caliband-launch-contract.md
@@ -1,0 +1,77 @@
+# caliband launch contract — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** Make the reconciled Sandbox actually run a live caliband: daemon `args`, a git-clone init container to populate the workspace, and the mismatched env removed. See [ADR 0003](../adr/0003-caliband-launch-contract.md).
+
+**Scope:** `caliban-operator` only — `src/resources.rs` (`build_sandbox`/`caliband_env`) + `src/config.rs` (`Settings`). Pure builders, unit-tested.
+
+## Global Constraints
+- Use only flags caliband's arg parser accepts: `--workspace-root <path>`, `--listen <host:port>` (plaintext OK; TLS/token deferred). `--workspace-root` is **required**.
+- Cluster-agnostic: the git image is a `Settings` knob with a neutral public default; no home-cluster identifiers.
+- Idempotent clone (skip if `<path>/.git` exists) — the workspace PVC persists across restarts.
+- `LocalFleet`/other behavior unaffected; keep the `common_labels` on the podTemplate (NetworkPolicy selector) and the token-less SA.
+
+---
+
+### Task 1: Run caliband as a daemon + drop mismatched env
+
+**Files:** `src/resources.rs` (`build_sandbox`, `caliband_env`).
+
+- [ ] In `build_sandbox`, set the caliband container's `args` (k8s `args` overrides the image `CMD ["--help"]`, keeps `ENTRYPOINT ["caliband"]`):
+  ```rust
+  args: Some(vec![
+      "--workspace-root".to_string(), s.workspace_root.clone(),
+      "--listen".to_string(), format!("0.0.0.0:{}", s.caliband_port),
+  ]),
+  ```
+- [ ] In `caliband_env`, REMOVE the three vars caliband/caliban do not read: `CALIBAND_LISTEN`, `CALIBAN_WORKSPACE_ROOT`, `CALIBAN_WORKSPACE_SOURCES`. KEEP the conditional `GONZALO_ENDPOINT` and `CALIBAN_ROUTER_CONFIG_REF` (agent-runtime env, harmless). `caliband_env` may now return an empty vec when neither is set — that's fine (`env: Some(vec![])` or drop `env` when empty; either is acceptable).
+- [ ] Update tests: the existing `sandbox_has_caliband_container_pvc_and_service` asserts `CALIBAND_LISTEN`/`CALIBAN_WORKSPACE_ROOT` env — replace those assertions with: the container `args` contain `--workspace-root <root>` and `--listen 0.0.0.0:<port>` (in order), and assert the three removed env vars are ABSENT. Keep the router-config env test (`sandbox_projects_router_config_ref_env_when_model_set`) and the runtimeClass test.
+- [ ] `cargo fmt --all`; `cargo clippy --workspace --all-targets --features … -- -D warnings` (match the repo's gate); `cargo test --workspace`. All green. Regenerate CRD if crdgen output changes (it won't — no CRD change).
+- [ ] Commit: `fix(operator): run caliband as a daemon (--workspace-root/--listen), drop mismatched env (#366)`
+
+---
+
+### Task 2: git-clone init container to populate the workspace
+
+**Files:** `src/config.rs` (`Settings`), `src/resources.rs` (`build_sandbox`).
+
+- [ ] Add a `git_image: String` field to `Settings` (default a neutral public image, e.g. `"alpine/git:latest"`; env `CALIBAN_GIT_IMAGE`). Add to `Settings::default()` + `from_env()`. Assert the default is neutral (no "home") in the existing `from_env_defaults_are_neutral` test.
+- [ ] In `build_sandbox`, add an `init_containers` entry to the `PodSpec` that mounts the workspace volume (same `WORKSPACE_VOLUME` at `s.workspace_root`) and clones each source idempotently. Build the shell script from `t.spec.workspace.sources`:
+  ```rust
+  fn clone_script(t: &CalibanTask) -> String {
+      let mut s = String::from("set -eu\n");
+      for src in &t.spec.workspace.sources {
+          // idempotent: skip if already cloned onto the persistent PVC
+          s.push_str(&format!(
+              "if [ ! -d '{path}/.git' ]; then git clone --depth 1 --branch '{r#ref}' '{repo}' '{path}'; fi\n",
+              path = src.path, r#ref = src.r#ref, repo = src.repo,
+          ));
+      }
+      s
+  }
+  ```
+  The init container:
+  ```rust
+  Container {
+      name: "clone-workspace".to_string(),
+      image: Some(s.git_image.clone()),
+      command: Some(vec!["/bin/sh".to_string(), "-c".to_string(), clone_script(t)]),
+      volume_mounts: Some(vec![VolumeMount {
+          name: WORKSPACE_VOLUME.to_string(),
+          mount_path: s.workspace_root.clone(),
+          ..Default::default()
+      }]),
+      ..Default::default()
+  }
+  ```
+  Set `pod_spec.init_containers = Some(vec![that])`. If `sources` is empty, still emit the container with a no-op script (harmless) OR skip it — pick one and note it (skipping when empty is cleaner).
+- [ ] Tests: `build_sandbox` for a task with a source produces an init container named `clone-workspace` whose image is the `git_image` default, mounting the workspace volume, whose command script contains `git clone --depth 1 --branch main '<repo>' '<path>'` and the idempotency guard `[ ! -d '<path>/.git' ]`. (Use the existing `task()` fixture's source.)
+- [ ] Gate green (fmt/clippy/build/test). CRD unchanged.
+- [ ] Commit: `feat(operator): git-clone init container populates the workspace PVC (#366)`
+
+---
+
+## Notes
+- **Deferred (ADR 0003):** TLS/token for the transport (plaintext for now); `--advertise-host`/per-agent port routing (pairs with prospero #77); private-source credential projection.
+- The caliband arg parser is in `caliban/crates/caliban-supervisor/src/bin/caliban.rs` (`caliband.rs`) — flags: `--workspace-root` (required), `--listen`, `--socket-path`, `--data-base`, `--advertise-host`, `--agent-port-base`, `--tls-*`, `--token`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,8 @@ pub struct Settings {
     pub workspace_root: String,
     /// Requested size of the workspace PVC (e.g. `10Gi`).
     pub workspace_storage: String,
+    /// Container image for the git-clone init container that populates the workspace.
+    pub git_image: String,
 }
 
 impl Default for Settings {
@@ -28,13 +30,14 @@ impl Default for Settings {
             caliband_port: 8443,
             workspace_root: "/work".to_string(),
             workspace_storage: "10Gi".to_string(),
+            git_image: "alpine/git:latest".to_string(),
         }
     }
 }
 
 impl Settings {
     /// Read settings from `CALIBAND_IMAGE`, `CALIBAND_PORT`, `CALIBAN_WORKSPACE_ROOT`,
-    /// `CALIBAN_WORKSPACE_STORAGE`, falling back to defaults.
+    /// `CALIBAN_WORKSPACE_STORAGE`, `CALIBAN_GIT_IMAGE`, falling back to defaults.
     pub fn from_env() -> Self {
         let d = Self::default();
         Self {
@@ -46,6 +49,7 @@ impl Settings {
             workspace_root: std::env::var("CALIBAN_WORKSPACE_ROOT").unwrap_or(d.workspace_root),
             workspace_storage: std::env::var("CALIBAN_WORKSPACE_STORAGE")
                 .unwrap_or(d.workspace_storage),
+            git_image: std::env::var("CALIBAN_GIT_IMAGE").unwrap_or(d.git_image),
         }
     }
 }
@@ -144,5 +148,7 @@ mod tests {
         assert_eq!(s.caliband_port, 8443);
         assert!(!s.caliband_image.contains("home"));
         assert_eq!(s.workspace_root, "/work");
+        assert!(!s.git_image.contains("home"));
+        assert!(!s.git_image.is_empty());
     }
 }

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -110,6 +110,11 @@ fn caliband_env(t: &CalibanTask) -> Vec<EnvVar> {
     e
 }
 
+/// POSIX single-quote a value for safe interpolation into `/bin/sh -c`.
+fn sh_squote(v: &str) -> String {
+    format!("'{}'", v.replace('\'', "'\\''"))
+}
+
 /// Build the idempotent clone script for the init container: for each workspace
 /// source, clone `repo` at `ref` into `path` unless it's already a git checkout
 /// (so pause/resume and pod restarts over the persistent PVC don't refetch).
@@ -117,8 +122,11 @@ fn clone_script(t: &CalibanTask) -> String {
     let mut s = String::from("set -eu\n");
     for src in &t.spec.workspace.sources {
         s.push_str(&format!(
-            "if [ ! -d '{path}/.git' ]; then git clone --depth 1 --branch '{r}' '{repo}' '{path}'; fi\n",
-            path = src.path, r = src.r#ref, repo = src.repo,
+            "if [ ! -d {git} ]; then git clone --depth 1 --branch {r} {repo} {path}; fi\n",
+            git = sh_squote(&format!("{}/.git", src.path)),
+            r = sh_squote(&src.r#ref),
+            repo = sh_squote(&src.repo),
+            path = sh_squote(&src.path),
         ));
     }
     s
@@ -400,6 +408,18 @@ mod tests {
             script.contains("git clone --depth 1 --branch 'main' 'git@x:caliban' '/work/caliban'")
         );
         assert!(script.contains("[ ! -d '/work/caliban/.git' ]"));
+    }
+
+    #[test]
+    fn clone_script_shell_escapes_source_values() {
+        let mut t = task();
+        t.spec.workspace.sources[0].repo = "https://x/a'b".into();
+        let sb = build_sandbox(&t, &Settings::default());
+        let pod = sb.spec.pod_template.spec.unwrap();
+        let init = &pod.init_containers.unwrap()[0];
+        let script = &init.command.as_ref().unwrap()[2];
+        assert!(script.contains("'https://x/a'\\''b'"));
+        assert!(!script.contains("'https://x/a'b'"));
     }
 
     #[test]

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -89,16 +89,8 @@ fn env(name: &str, value: String) -> EnvVar {
     }
 }
 
-fn caliband_env(t: &CalibanTask, s: &Settings) -> Vec<EnvVar> {
-    let sources = serde_json::to_string(&t.spec.workspace.sources).unwrap_or_else(|_| "[]".into());
-    let mut e = vec![
-        env(
-            "CALIBAND_LISTEN",
-            format!("tcp://0.0.0.0:{}", s.caliband_port),
-        ),
-        env("CALIBAN_WORKSPACE_ROOT", s.workspace_root.clone()),
-        env("CALIBAN_WORKSPACE_SOURCES", sources),
-    ];
+fn caliband_env(t: &CalibanTask, _s: &Settings) -> Vec<EnvVar> {
+    let mut e = vec![];
     if let Some(ep) = t
         .spec
         .state
@@ -151,6 +143,12 @@ pub fn build_sandbox(t: &CalibanTask, s: &Settings) -> Sandbox {
             name: Some("caliband".to_string()),
             ..Default::default()
         }]),
+        args: Some(vec![
+            "--workspace-root".to_string(),
+            s.workspace_root.clone(),
+            "--listen".to_string(),
+            format!("0.0.0.0:{}", s.caliband_port),
+        ]),
         env: Some(caliband_env(t, s)),
         volume_mounts: Some(vec![VolumeMount {
             name: WORKSPACE_VOLUME.to_string(),
@@ -306,12 +304,23 @@ mod tests {
             Some("ghcr.io/caliban-ai/caliban:latest")
         );
         assert_eq!(c.ports.as_ref().unwrap()[0].container_port, 8443);
-        // Env projects the listen addr + workspace root.
+        // Args run caliband as a daemon: --workspace-root <root> --listen 0.0.0.0:<port>.
+        let args = c.args.as_ref().unwrap();
+        let root_idx = args
+            .iter()
+            .position(|a| a == "--workspace-root")
+            .expect("--workspace-root flag present");
+        assert_eq!(args[root_idx + 1], s.workspace_root);
+        let listen_idx = args
+            .iter()
+            .position(|a| a == "--listen")
+            .expect("--listen flag present");
+        assert_eq!(args[listen_idx + 1], "0.0.0.0:8443");
+        // The mismatched env vars from #283 must not reappear.
         let env = c.env.as_ref().unwrap();
-        assert!(env.iter().any(
-            |e| e.name == "CALIBAND_LISTEN" && e.value.as_deref() == Some("tcp://0.0.0.0:8443")
-        ));
-        assert!(env.iter().any(|e| e.name == "CALIBAN_WORKSPACE_ROOT"));
+        assert!(!env.iter().any(|e| e.name == "CALIBAND_LISTEN"));
+        assert!(!env.iter().any(|e| e.name == "CALIBAN_WORKSPACE_ROOT"));
+        assert!(!env.iter().any(|e| e.name == "CALIBAN_WORKSPACE_SOURCES"));
         // No model configured in the default fixture → no router-config env.
         assert!(!env.iter().any(|e| e.name == "CALIBAN_ROUTER_CONFIG_REF"));
         // Workspace PVC present.

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -89,7 +89,7 @@ fn env(name: &str, value: String) -> EnvVar {
     }
 }
 
-fn caliband_env(t: &CalibanTask, _s: &Settings) -> Vec<EnvVar> {
+fn caliband_env(t: &CalibanTask) -> Vec<EnvVar> {
     let mut e = vec![];
     if let Some(ep) = t
         .spec
@@ -108,6 +108,43 @@ fn caliband_env(t: &CalibanTask, _s: &Settings) -> Vec<EnvVar> {
         e.push(env("CALIBAN_ROUTER_CONFIG_REF", r));
     }
     e
+}
+
+/// Build the idempotent clone script for the init container: for each workspace
+/// source, clone `repo` at `ref` into `path` unless it's already a git checkout
+/// (so pause/resume and pod restarts over the persistent PVC don't refetch).
+fn clone_script(t: &CalibanTask) -> String {
+    let mut s = String::from("set -eu\n");
+    for src in &t.spec.workspace.sources {
+        s.push_str(&format!(
+            "if [ ! -d '{path}/.git' ]; then git clone --depth 1 --branch '{r}' '{repo}' '{path}'; fi\n",
+            path = src.path, r = src.r#ref, repo = src.repo,
+        ));
+    }
+    s
+}
+
+/// The git-clone init container that populates the workspace volume from
+/// `spec.workspace.sources[]`, if any are configured.
+fn clone_init_container(t: &CalibanTask, s: &Settings) -> Option<Container> {
+    if t.spec.workspace.sources.is_empty() {
+        return None;
+    }
+    Some(Container {
+        name: "clone-workspace".to_string(),
+        image: Some(s.git_image.clone()),
+        command: Some(vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            clone_script(t),
+        ]),
+        volume_mounts: Some(vec![VolumeMount {
+            name: WORKSPACE_VOLUME.to_string(),
+            mount_path: s.workspace_root.clone(),
+            ..Default::default()
+        }]),
+        ..Default::default()
+    })
 }
 
 fn workspace_pvc(s: &Settings) -> PersistentVolumeClaim {
@@ -149,7 +186,7 @@ pub fn build_sandbox(t: &CalibanTask, s: &Settings) -> Sandbox {
             "--listen".to_string(),
             format!("0.0.0.0:{}", s.caliband_port),
         ]),
-        env: Some(caliband_env(t, s)),
+        env: Some(caliband_env(t)),
         volume_mounts: Some(vec![VolumeMount {
             name: WORKSPACE_VOLUME.to_string(),
             mount_path: s.workspace_root.clone(),
@@ -159,6 +196,7 @@ pub fn build_sandbox(t: &CalibanTask, s: &Settings) -> Sandbox {
     };
     let pod_spec = PodSpec {
         containers: vec![container],
+        init_containers: clone_init_container(t, s).map(|c| vec![c]),
         runtime_class_name: t
             .spec
             .isolation
@@ -335,6 +373,42 @@ mod tests {
             .labels
             .unwrap()
             .contains_key("caliban.caliban-ai.dev/task"));
+    }
+
+    #[test]
+    fn sandbox_has_git_clone_init_container_for_workspace_sources() {
+        let s = Settings::default();
+        let sb = build_sandbox(&task(), &s);
+        let pod = sb.spec.pod_template.spec.unwrap();
+        let inits = pod.init_containers.expect("init containers present");
+        assert_eq!(inits.len(), 1);
+        let init = &inits[0];
+        assert_eq!(init.name, "clone-workspace");
+        assert_eq!(
+            init.image.as_deref(),
+            Some(Settings::default().git_image.as_str())
+        );
+        let mounts = init.volume_mounts.as_ref().unwrap();
+        assert_eq!(mounts.len(), 1);
+        assert_eq!(mounts[0].name, "workspace");
+        assert_eq!(mounts[0].mount_path, s.workspace_root);
+        let command = init.command.as_ref().unwrap();
+        assert_eq!(command[0], "/bin/sh");
+        assert_eq!(command[1], "-c");
+        let script = &command[2];
+        assert!(
+            script.contains("git clone --depth 1 --branch 'main' 'git@x:caliban' '/work/caliban'")
+        );
+        assert!(script.contains("[ ! -d '/work/caliban/.git' ]"));
+    }
+
+    #[test]
+    fn sandbox_omits_init_containers_when_no_workspace_sources() {
+        let mut t = task();
+        t.spec.workspace.sources = vec![];
+        let sb = build_sandbox(&t, &Settings::default());
+        let pod = sb.spec.pod_template.spec.unwrap();
+        assert!(pod.init_containers.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## What

Make the reconciled Sandbox actually **launch a live caliband** — closing the gap a home-cluster dry run exposed between "the operator renders correct objects" (#283) and "a caliband agent actually runs." Closes caliban-ai/caliban#366 (follow-up to #283). Part of the k8s epic #274.

## The gaps (found by tracing caliban's arg parser)

#283's `build_sandbox` set no container `command`/`args` (so the pod ran the image's default `CMD ["--help"]` → exit → CrashLoop) and projected env caliband doesn't read (`CALIBAND_LISTEN`, `CALIBAN_WORKSPACE_ROOT`, `CALIBAN_WORKSPACE_SOURCES`), and nothing populated the `/work` PVC.

## Fix (ADR 0003)

- **Run caliband as a daemon** via container `args`: `--workspace-root <root> --listen 0.0.0.0:<port>` — using only flags caliband's parser accepts (`--workspace-root` is required; `--listen` is the network switch; TLS/token optional → **plaintext TCP** for the first e2e).
- **Dropped the three mismatched env vars**; kept `GONZALO_ENDPOINT` / `CALIBAN_ROUTER_CONFIG_REF` (agent-runtime env).
- **git-clone init container** (`clone-workspace`, image from a new `git_image` setting, default `alpine/git:latest`) populates the workspace PVC — clones each `spec.workspace.sources[]` (`repo`@`ref` → `path`) **idempotently** (skips if `<path>/.git` exists, so pause/resume and restarts over the persistent PVC don't refetch/fail). The clone script **shell-escapes** all CR-derived values (POSIX single-quote escaping) — the whole-branch review caught an injection/breakage surface, now fixed with a regression test.

## Test

`fmt` / `clippy -D warnings` / `build` / `test` (**24 passing**) all green; `crdgen` output byte-identical to the committed CRD (no CRD change). Subagent-driven with per-task + Opus whole-branch review.

## Deferred (ADR 0003, tracked)

TLS/token for the transport (plaintext now); `--advertise-host` + per-agent port routing (pairs with prospero #77); private-source credential projection; `--branch <ref>` accepts branch/tag names only, not commit SHAs.
