### PR TITLE
fix(sandbox): emit volumeClaimTemplates without TypeMeta (#7)

### DIFF
--- a/src/resources.rs
+++ b/src/resources.rs
@@ -5,8 +5,8 @@
 use std::collections::BTreeMap;
 
 use k8s_openapi::api::core::v1::{
-    Container, ContainerPort, EnvVar, PersistentVolumeClaim, PersistentVolumeClaimSpec, PodSpec,
-    PodTemplateSpec, ServiceAccount, VolumeMount, VolumeResourceRequirements,
+    Container, ContainerPort, EnvVar, PersistentVolumeClaimSpec, PodSpec, PodTemplateSpec,
+    ServiceAccount, VolumeMount, VolumeResourceRequirements,
 };
 use k8s_openapi::api::networking::v1::{
     NetworkPolicy, NetworkPolicyEgressRule, NetworkPolicyIngressRule, NetworkPolicyPeer,
@@ -19,7 +19,7 @@ use kube::ResourceExt;
 
 use crate::config::{common_labels, netpol_name, owner_ref, sa_name, sandbox_name, Settings};
 use crate::crd::CalibanTask;
-use crate::sandbox::{Sandbox, SandboxSpec};
+use crate::sandbox::{Sandbox, SandboxSpec, VolumeClaimTemplate};
 
 fn child_meta(t: &CalibanTask, name: String, labels: BTreeMap<String, String>) -> ObjectMeta {
     ObjectMeta {
@@ -155,8 +155,8 @@ fn clone_init_container(t: &CalibanTask, s: &Settings) -> Option<Container> {
     })
 }
 
-fn workspace_pvc(s: &Settings) -> PersistentVolumeClaim {
-    PersistentVolumeClaim {
+fn workspace_pvc(s: &Settings) -> VolumeClaimTemplate {
+    VolumeClaimTemplate {
         metadata: ObjectMeta {
             name: Some(WORKSPACE_VOLUME.to_string()),
             ..Default::default()
@@ -173,7 +173,6 @@ fn workspace_pvc(s: &Settings) -> PersistentVolumeClaim {
             // storageClassName unset → cluster default (cluster-agnostic).
             ..Default::default()
         }),
-        ..Default::default()
     }
 }
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -4,7 +4,8 @@
 //! CRD (agent-sandbox owns it), so `Sandbox::crd()` is intentionally unused. See
 //! ADR 0002.
 
-use k8s_openapi::api::core::v1::{PersistentVolumeClaim, PodTemplateSpec};
+use k8s_openapi::api::core::v1::{PersistentVolumeClaimSpec, PodTemplateSpec};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -30,7 +31,23 @@ pub struct SandboxSpec {
     pub operating_mode: Option<String>,
     /// PVCs materialized for the sandbox (persist across restarts).
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub volume_claim_templates: Option<Vec<PersistentVolumeClaim>>,
+    pub volume_claim_templates: Option<Vec<VolumeClaimTemplate>>,
+}
+
+/// A `volumeClaimTemplates` entry as agent-sandbox's `Sandbox` schema declares it:
+/// a bare embedded PVC template (`metadata` + `spec`) with **no** `apiVersion`/`kind`.
+///
+/// We must NOT use k8s-openapi's `PersistentVolumeClaim` here: it serializes its
+/// group/version/kind, and agent-sandbox v0.5.0's structural schema rejects those on
+/// server-side apply (`.spec.volumeClaimTemplates[].apiVersion: field not declared in
+/// schema`), which fails every reconcile.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct VolumeClaimTemplate {
+    #[serde(default)]
+    pub metadata: ObjectMeta,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spec: Option<PersistentVolumeClaimSpec>,
 }
 
 /// Observed state of a `Sandbox` (subset the operator reads).
@@ -67,6 +84,36 @@ mod tests {
         assert_eq!(v["spec"]["service"], true);
         assert_eq!(v["spec"]["operatingMode"], "Running");
         assert!(v["spec"]["podTemplate"].is_object());
+    }
+
+    #[test]
+    fn volume_claim_templates_carry_no_type_meta() {
+        // agent-sandbox v0.5.0's Sandbox schema declares only `metadata`/`spec` on
+        // volumeClaimTemplates items; emitting apiVersion/kind fails the SSA with
+        // "field not declared in schema". Guard against regressing to a full PVC.
+        let sb = Sandbox::new(
+            "demo-sbx",
+            SandboxSpec {
+                pod_template: PodTemplateSpec::default(),
+                service: None,
+                operating_mode: None,
+                volume_claim_templates: Some(vec![VolumeClaimTemplate {
+                    metadata: ObjectMeta {
+                        name: Some("workspace".to_string()),
+                        ..Default::default()
+                    },
+                    spec: None,
+                }]),
+            },
+        );
+        let v = serde_json::to_value(&sb).unwrap();
+        let vct = &v["spec"]["volumeClaimTemplates"][0];
+        assert!(
+            vct.get("apiVersion").is_none(),
+            "must not emit apiVersion: {vct}"
+        );
+        assert!(vct.get("kind").is_none(), "must not emit kind: {vct}");
+        assert_eq!(vct["metadata"]["name"], "workspace");
     }
 
     #[test]


### PR DESCRIPTION
Closes #7.

Every `CalibanTask` reconcile failed at Sandbox creation: the operator built
`Sandbox.spec.volumeClaimTemplates` from k8s-openapi `PersistentVolumeClaim`, which
serializes its group/version/kind. agent-sandbox v0.5.0's structural schema doesn't
declare `apiVersion`/`kind` on those items, so the server-side apply was rejected —
`.spec.volumeClaimTemplates[0].apiVersion: field not declared in schema` (500) — and no
Sandbox was ever created.

## Fix
- New `VolumeClaimTemplate { metadata, spec }` type (no `TypeMeta`) in `src/sandbox.rs`;
  `SandboxSpec.volume_claim_templates` now uses it.
- `workspace_pvc()` (`src/resources.rs`) builds that bare template.
- Serialization test asserts the emitted item carries no `apiVersion`/`kind`.

## Verification
- `cargo fmt`/`clippy -D warnings`/`build`/`test` all green (25 tests).
- Against the **real agent-sandbox v0.5.0 CRD** (server-side dry-run): the new shape
  applies cleanly; the old PVC shape still reproduces the rejection.
- Reproduced originally by `helm-charts` `test/integration/level3.sh`; that Level 3 gate
  should progress past this error once a fixed operator image is published.