### PR TITLE
release: v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "caliban-operator"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "caliban-operator"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Kubernetes operator (kube-rs) for caliban agent workloads (scaffolding — see caliban-ai/caliban#282)"


### PR DESCRIPTION
Bumps the crate version to 0.1.1. Tagging `v0.1.1` on the merge commit triggers `release-image.yml` to publish `ghcr.io/caliban-ai/caliban-operator:0.1.1` (multi-arch).

Ships the volumeClaimTemplates TypeMeta fix (#7, #8) — the first operator build whose reconcile creates a Sandbox agent-sandbox v0.5.0 accepts (verified end-to-end: CalibanTask → Sandbox → status.phase=Running).