### PR TITLE
fix(operator): harden CRD validation, graceful shutdown, serde_yaml migration (#2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,7 +158,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_norway",
  "thiserror",
  "tokio",
  "tracing",
@@ -1484,16 +1484,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_norway"
+version = "0.9.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
 dependencies = [
  "indexmap",
  "itoa",
  "ryu",
  "serde",
- "unsafe-libyaml",
+ "unsafe-libyaml-norway",
 ]
 
 [[package]]
@@ -1786,10 +1786,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,11 @@ kube = { version = "4.0.0", features = ["runtime", "derive", "client"] }
 schemars = "1.2.1"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
-serde_yaml = "0.9.34"
+# serde_norway is the maintained fork of the unmaintained serde_yaml (RUSTSEC),
+# with the same API and byte-identical emitter (keeps crdgen ↔ sync-test stable).
+serde_norway = "0.9.42"
 thiserror = "2.0.18"
-tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread", "signal"] }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 

--- a/deploy/crd/calibantask.yaml
+++ b/deploy/crd/calibantask.yaml
@@ -94,6 +94,7 @@ spec:
                     type: string
                   prompt:
                     description: Initial prompt.
+                    minLength: 1
                     type: string
                 required:
                 - prompt
@@ -114,9 +115,11 @@ spec:
                       properties:
                         name:
                           description: Source identifier (matches caliband's workspace source name).
+                          minLength: 1
                           type: string
                         path:
                           description: Absolute mount path in the pod (e.g. `/work/caliban`).
+                          minLength: 1
                           type: string
                         ref:
                           default: main
@@ -124,12 +127,14 @@ spec:
                           type: string
                         repo:
                           description: Git remote to clone.
+                          minLength: 1
                           type: string
                       required:
                       - name
                       - path
                       - repo
                       type: object
+                    minItems: 1
                     type: array
                 required:
                 - sources

--- a/src/bin/crdgen.rs
+++ b/src/bin/crdgen.rs
@@ -4,6 +4,6 @@ use kube::CustomResourceExt;
 
 fn main() -> anyhow::Result<()> {
     let crd = caliban_operator::crd::CalibanTask::crd();
-    print!("{}", serde_yaml::to_string(&crd)?);
+    print!("{}", serde_norway::to_string(&crd)?);
     Ok(())
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -126,6 +126,9 @@ pub async fn run(client: Client) -> anyhow::Result<()> {
         settings: Settings::from_env(),
     });
     Controller::new(tasks, Config::default())
+        // Drain in-flight reconciles on SIGTERM/SIGINT (pod termination, Ctrl+C)
+        // instead of hard-killing mid-reconcile.
+        .shutdown_on_signal()
         .run(reconcile, error_policy, ctx)
         .for_each(|res| async move {
             match res {

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -45,6 +45,7 @@ pub struct CalibanTaskSpec {
 #[serde(rename_all = "camelCase")]
 pub struct Workspace {
     /// The guaranteed source checkouts (runtime-extensible).
+    #[schemars(length(min = 1))]
     pub sources: Vec<Source>,
     /// Optional in-pod aux services (e.g. gonzalod, prosperod) for e2e.
     #[serde(default)]
@@ -56,13 +57,16 @@ pub struct Workspace {
 #[serde(rename_all = "camelCase")]
 pub struct Source {
     /// Source identifier (matches caliband's workspace source name).
+    #[schemars(length(min = 1))]
     pub name: String,
     /// Git remote to clone.
+    #[schemars(length(min = 1))]
     pub repo: String,
     /// Git ref to check out. Defaults to `main`.
     #[serde(default = "default_ref")]
     pub r#ref: String,
     /// Absolute mount path in the pod (e.g. `/work/caliban`).
+    #[schemars(length(min = 1))]
     pub path: String,
 }
 
@@ -75,6 +79,7 @@ fn default_ref() -> String {
 #[serde(rename_all = "camelCase")]
 pub struct TaskSpec {
     /// Initial prompt.
+    #[schemars(length(min = 1))]
     pub prompt: String,
     /// Agent type (e.g. `general-purpose`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -248,7 +253,7 @@ spec:
 
     #[test]
     fn sample_cr_round_trips() {
-        let task: CalibanTask = serde_yaml::from_str(SAMPLE).expect("deserialize sample");
+        let task: CalibanTask = serde_norway::from_str(SAMPLE).expect("deserialize sample");
         assert_eq!(task.spec.workspace.sources.len(), 2);
         assert_eq!(task.spec.workspace.sources[0].name, "caliban");
         assert_eq!(task.spec.workspace.sources[1].r#ref, "feat-xport");
@@ -297,12 +302,40 @@ spec:
 
     #[test]
     fn committed_crd_yaml_is_in_sync() {
-        let generated = serde_yaml::to_string(&CalibanTask::crd()).unwrap();
+        let generated = serde_norway::to_string(&CalibanTask::crd()).unwrap();
         let committed = include_str!("../deploy/crd/calibantask.yaml");
         assert_eq!(
             generated.trim(),
             committed.trim(),
             "deploy/crd/calibantask.yaml is stale — regenerate: cargo run --bin crdgen > deploy/crd/calibantask.yaml"
+        );
+    }
+
+    #[test]
+    fn crd_enforces_non_empty_required_fields() {
+        // Semantically-invalid CRs (`sources: []`, `prompt: ""`) must be rejected
+        // by the API server, not admitted and set to Pending. The generated CRD
+        // schema carries the constraints (schemars `length(min = 1)`).
+        let crd = CalibanTask::crd();
+        let schema = serde_json::to_value(&crd.spec.versions[0].schema).unwrap();
+        let spec = &schema["openAPIV3Schema"]["properties"]["spec"]["properties"];
+
+        // sources: at least one checkout.
+        assert_eq!(
+            spec["workspace"]["properties"]["sources"]["minItems"], 1,
+            "workspace.sources must require minItems: 1"
+        );
+        // Required strings: no empty values.
+        let source_props = &spec["workspace"]["properties"]["sources"]["items"]["properties"];
+        for field in ["name", "repo", "path"] {
+            assert_eq!(
+                source_props[field]["minLength"], 1,
+                "source.{field} must require minLength: 1"
+            );
+        }
+        assert_eq!(
+            spec["task"]["properties"]["prompt"]["minLength"], 1,
+            "task.prompt must require minLength: 1"
         );
     }
 
@@ -317,7 +350,7 @@ spec:
   workspace: { sources: [ { name: only, repo: "git@x:only", path: /work/only } ] }
   task: { prompt: hi }
 "#;
-        let task: CalibanTask = serde_yaml::from_str(yaml).unwrap();
+        let task: CalibanTask = serde_norway::from_str(yaml).unwrap();
         assert_eq!(task.spec.workspace.sources[0].r#ref, "main"); // default ref
         assert!(task.spec.workspace.services.is_empty());
         assert!(task.spec.model.is_none());


### PR DESCRIPTION
Deferred minors from the #282 (kube-rs scaffold + CalibanTask CRD) whole-branch review. Closes #2.

## What

1. **CRD schema validation** — added schemars `length(min = 1)` on:
   - `workspace.sources: Vec<Source>` → `minItems: 1`
   - required strings `task.prompt`, `source.name`, `source.repo`, `source.path` → `minLength: 1`

   So semantically-invalid CRs (`sources: []`, `prompt: ""`) are now **rejected by the API server** rather than admitted and set to `Pending`. Regenerated `deploy/crd/calibantask.yaml`; the existing sync test guards regeneration, plus a new `crd_enforces_non_empty_required_fields` test asserts the constraints from the generated schema.

2. **Graceful shutdown** — `Controller::shutdown_on_signal()` drains in-flight reconciles on **SIGTERM/SIGINT** (pod termination, Ctrl+C) instead of hard-killing mid-reconcile. Adds the tokio `signal` feature.

3. **serde_yaml → serde_norway** — `serde_yaml 0.9` is archived/unmaintained (RUSTSEC). Swapped to `serde_norway`, the maintained drop-in fork. Its emitter is **byte-identical**, so the only CRD YAML change is the new constraints above (verified via the regen diff).

## Test

Full local gate green (mirrors `ci.yml`): `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo build --all-targets`, `cargo test` — 26 passed.

The CRD schema constraints are CI-testable (unit + sync test). Graceful shutdown is a wiring change verified by compilation against the kube-runtime 4.0 API; the serde_norway swap is verified byte-identical by the regenerated-YAML diff.