### PR TITLE
feat(crd)!: Workspace CRD + CalibanTask workspaceRef/providerRef resolve-and-pin (#11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,22 +6,36 @@
 Kubernetes operator (Rust / [kube-rs](https://kube.rs)) for **caliban** agent
 workloads. It composes the Kubernetes SIG
 [agent-sandbox](https://agent-sandbox.sigs.k8s.io) project and reconciles a
-`CalibanTask` custom resource into a sandboxed agent pod.
+`Workspace` + `CalibanTask` pair of custom resources into a sandboxed agent pod.
 
-> **Status:** repository scaffolding only. The `CalibanTask` CRD and the
-> reconcile loop land in follow-up tickets. See the full design in the
-> [k8s system design spec](https://github.com/caliban-ai/caliban) and the
-> umbrella epic **caliban-ai/caliban#274**.
+> **Status:** the `Workspace` and `CalibanTask` CRDs and their reconcile loops are
+> implemented (see [`docs/adr/`](docs/adr/README.md) for the accepted decisions).
+> See the full design in the [k8s system design spec](https://github.com/caliban-ai/caliban)
+> and the umbrella epic **caliban-ai/caliban#274**.
 
 ## Role in the system
 
 ```
-prospero --CRUD/watch--> CalibanTask CR --reconcile--> agent-sandbox Sandbox pod
-                          (this operator)                caliband + caliban agents
+prospero --CRUD--------> Workspace CR (sources, named providers, credentialsRef)
+                          (this operator validates + reports status)
+
+prospero --CRUD/watch--> CalibanTask CR (workspaceRef, providerRef)
+                          --reconcile--> agent-sandbox Sandbox pod
+                          (this operator)    caliband + caliban agents
 ```
 
+- **Config plane:** a namespaced `Workspace` CR holds durable, shared config —
+  git `sources` and named model `providers` (each with an optional
+  `credentialsRef` naming a Secret+key). The operator is the **sole** reader of
+  Secret values; prospero only ever sees the by-name reference. A `CalibanTask`
+  points at a `Workspace` via `workspaceRef` plus an optional `providerRef`; the
+  operator resolves the referenced provider and pins it into
+  `status.resolvedWorkspace` at admission, so a running task's config can't shift
+  underneath it even if the `Workspace` is edited later. See
+  [ADR 0004](docs/adr/0004-workspace-crd-and-resolve-and-pin.md). Sample CRs live in
+  [`deploy/samples/`](deploy/samples/).
 - **Provisioning plane:** the operator owns Sandbox/pod lifecycle, RBAC, and
-  NetworkPolicy; prospero needs only CRUD on `CalibanTask`.
+  NetworkPolicy; prospero needs only CRUD on `Workspace`/`CalibanTask`.
 - **Session plane:** live agent streaming/steering goes directly to caliband
   over gRPC/TLS (not through this operator).
 

--- a/deploy/crd/calibantask.yaml
+++ b/deploy/crd/calibantask.yaml
@@ -63,6 +63,12 @@ spec:
                     nullable: true
                     type: string
                 type: object
+              providerRef:
+                description: |-
+                  Which of the workspace's providers to bind; defaults to the workspace's
+                  `defaultProvider` (or its sole provider).
+                nullable: true
+                type: string
               resources:
                 description: 'Resource class → a SandboxTemplate (consumed in #283).'
                 nullable: true
@@ -99,49 +105,25 @@ spec:
                 required:
                 - prompt
                 type: object
-              workspace:
-                description: The workspace (1..N source checkouts) the task runs over.
+              tools:
+                description: Per-run tool override (allow-list) for this task's agents.
+                items:
+                  type: string
+                nullable: true
+                type: array
+              workspaceRef:
+                description: Reference to the namespace-local `Workspace` this task runs against.
                 properties:
-                  services:
-                    default: []
-                    description: Optional in-pod aux services (e.g. gonzalod, prosperod) for e2e.
-                    items:
-                      type: string
-                    type: array
-                  sources:
-                    description: The guaranteed source checkouts (runtime-extensible).
-                    items:
-                      description: A single source checkout in the workspace.
-                      properties:
-                        name:
-                          description: Source identifier (matches caliband's workspace source name).
-                          minLength: 1
-                          type: string
-                        path:
-                          description: Absolute mount path in the pod (e.g. `/work/caliban`).
-                          minLength: 1
-                          type: string
-                        ref:
-                          default: main
-                          description: Git ref to check out. Defaults to `main`.
-                          type: string
-                        repo:
-                          description: Git remote to clone.
-                          minLength: 1
-                          type: string
-                      required:
-                      - name
-                      - path
-                      - repo
-                      type: object
-                    minItems: 1
-                    type: array
+                  name:
+                    description: Workspace object name.
+                    minLength: 1
+                    type: string
                 required:
-                - sources
+                - name
                 type: object
             required:
             - task
-            - workspace
+            - workspaceRef
             type: object
           status:
             description: Observed state of a `CalibanTask`.
@@ -190,6 +172,110 @@ spec:
                 - Completed
                 - Failed
                 type: string
+              resolvedWorkspace:
+                description: |-
+                  Resolved workspace config, pinned at admission (immutable run). Set once;
+                  later `Workspace` edits don't re-pin a running task.
+                nullable: true
+                properties:
+                  env:
+                    description: Non-secret env from the workspace.
+                    items:
+                      description: A non-secret environment entry.
+                      properties:
+                        name:
+                          description: Variable name.
+                          minLength: 1
+                          type: string
+                        value:
+                          description: Variable value.
+                          type: string
+                      required:
+                      - name
+                      - value
+                      type: object
+                    type: array
+                  isolation:
+                    description: Workspace default isolation.
+                    nullable: true
+                    properties:
+                      runtimeClass:
+                        description: RuntimeClass (e.g. `gvisor`, `kata`).
+                        nullable: true
+                        type: string
+                      worktrees:
+                        description: Worktree isolation strategy (e.g. `per-source`).
+                        nullable: true
+                        type: string
+                    type: object
+                  provider:
+                    description: The single provider this task binds to.
+                    properties:
+                      baseUrl:
+                        description: Base URL, if set.
+                        nullable: true
+                        type: string
+                      credentialsRef:
+                        description: Credential Secret reference, if the provider needs one.
+                        nullable: true
+                        properties:
+                          key:
+                            description: Key within the Secret's data.
+                            minLength: 1
+                            type: string
+                          secretName:
+                            description: Name of the Secret (same namespace).
+                            minLength: 1
+                            type: string
+                        required:
+                        - key
+                        - secretName
+                        type: object
+                      kind:
+                        description: Provider kind.
+                        type: string
+                      model:
+                        description: Model, if set.
+                        nullable: true
+                        type: string
+                      name:
+                        description: Provider name.
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
+                  sources:
+                    description: The workspace's source checkouts.
+                    items:
+                      description: A single source checkout in the workspace.
+                      properties:
+                        name:
+                          description: Source identifier (matches caliband's workspace source name).
+                          minLength: 1
+                          type: string
+                        path:
+                          description: Absolute mount path in the pod (e.g. `/work/caliban`).
+                          minLength: 1
+                          type: string
+                        ref:
+                          default: main
+                          description: Git ref to check out. Defaults to `main`.
+                          type: string
+                        repo:
+                          description: Git remote to clone.
+                          minLength: 1
+                          type: string
+                      required:
+                      - name
+                      - path
+                      - repo
+                      type: object
+                    type: array
+                required:
+                - provider
+                - sources
+                type: object
               sandboxRef:
                 description: The agent-sandbox Sandbox backing this task.
                 nullable: true

--- a/deploy/crd/calibantask.yaml
+++ b/deploy/crd/calibantask.yaml
@@ -138,6 +138,7 @@ spec:
                 nullable: true
                 type: string
               conditions:
+                default: []
                 description: Standard Kubernetes conditions.
                 items:
                   description: A minimal Kubernetes-style condition.

--- a/deploy/crd/workspace.yaml
+++ b/deploy/crd/workspace.yaml
@@ -1,0 +1,203 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workspaces.caliban.caliban-ai.dev
+spec:
+  group: caliban.caliban-ai.dev
+  names:
+    categories: []
+    kind: Workspace
+    plural: workspaces
+    shortNames:
+    - cws
+    singular: workspace
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for WorkspaceSpec via `CustomResource`
+        properties:
+          spec:
+            description: 'Desired state of a workspace: sources + named providers + defaults.'
+            properties:
+              defaultProvider:
+                description: |-
+                  Provider name agents get when they don't request one. Implicit when
+                  exactly one provider is defined.
+                nullable: true
+                type: string
+              displayName:
+                description: Human-friendly dashboard label.
+                minLength: 1
+                type: string
+              env:
+                description: Non-secret environment injected into every agent pod.
+                items:
+                  description: A non-secret environment entry.
+                  properties:
+                    name:
+                      description: Variable name.
+                      minLength: 1
+                      type: string
+                    value:
+                      description: Variable value.
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+              isolation:
+                description: Default isolation for agents launched against this workspace.
+                nullable: true
+                properties:
+                  runtimeClass:
+                    description: RuntimeClass (e.g. `gvisor`, `kata`).
+                    nullable: true
+                    type: string
+                  worktrees:
+                    description: Worktree isolation strategy (e.g. `per-source`).
+                    nullable: true
+                    type: string
+                type: object
+              providers:
+                description: Named providers (1..N) agents in this workspace can bind to.
+                items:
+                  description: A named model provider bound within a workspace.
+                  properties:
+                    baseUrl:
+                      description: Override base URL (e.g. `http://192.168.1.240:11434`).
+                      nullable: true
+                      type: string
+                    credentialsRef:
+                      description: |-
+                        Reference to an existing Secret for this provider's API key. Keyless
+                        providers (e.g. ollama) omit it.
+                      nullable: true
+                      properties:
+                        key:
+                          description: Key within the Secret's data.
+                          minLength: 1
+                          type: string
+                        secretName:
+                          description: Name of the Secret (same namespace).
+                          minLength: 1
+                          type: string
+                      required:
+                      - key
+                      - secretName
+                      type: object
+                    kind:
+                      description: Provider kind (e.g. `ollama`, `anthropic`, `openai`).
+                      minLength: 1
+                      type: string
+                    model:
+                      description: Default model for this provider.
+                      nullable: true
+                      type: string
+                    name:
+                      description: Provider identifier, unique within the workspace (e.g. `planner`).
+                      minLength: 1
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                minItems: 1
+                type: array
+              sources:
+                description: The workspace's git checkouts (1..N).
+                items:
+                  description: A single source checkout in the workspace.
+                  properties:
+                    name:
+                      description: Source identifier (matches caliband's workspace source name).
+                      minLength: 1
+                      type: string
+                    path:
+                      description: Absolute mount path in the pod (e.g. `/work/caliban`).
+                      minLength: 1
+                      type: string
+                    ref:
+                      default: main
+                      description: Git ref to check out. Defaults to `main`.
+                      type: string
+                    repo:
+                      description: Git remote to clone.
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  - path
+                  - repo
+                  type: object
+                minItems: 1
+                type: array
+            required:
+            - displayName
+            - providers
+            - sources
+            type: object
+          status:
+            description: Observed state of a `Workspace`.
+            nullable: true
+            properties:
+              conditions:
+                description: Standard Kubernetes conditions.
+                items:
+                  description: A minimal Kubernetes-style condition.
+                  properties:
+                    message:
+                      description: Human-readable message.
+                      nullable: true
+                      type: string
+                    reason:
+                      description: Machine-readable reason.
+                      nullable: true
+                      type: string
+                    status:
+                      description: '`True` / `False` / `Unknown`.'
+                      type: string
+                    type:
+                      description: Condition type (e.g. `Ready`).
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              message:
+                description: 'Human-readable detail (e.g. `provider ''planner'': secret ''anthropic-key'' not found`).'
+                nullable: true
+                type: string
+              observedGeneration:
+                description: The `.metadata.generation` this status reflects.
+                format: int64
+                nullable: true
+                type: integer
+              phase:
+                default: Pending
+                description: Lifecycle phase.
+                enum:
+                - Pending
+                - Reconciling
+                - Ready
+                - Failed
+                type: string
+            type: object
+        required:
+        - spec
+        title: Workspace
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/samples/calibantask.yaml
+++ b/deploy/samples/calibantask.yaml
@@ -1,0 +1,9 @@
+apiVersion: caliban.caliban-ai.dev/v1alpha1
+kind: CalibanTask
+metadata:
+  name: refactor-auth
+  namespace: team-a
+spec:
+  workspaceRef: { name: team-a-ws }
+  providerRef: workers
+  task: { prompt: "refactor the auth module", agentType: general-purpose }

--- a/deploy/samples/workspace.yaml
+++ b/deploy/samples/workspace.yaml
@@ -1,0 +1,19 @@
+apiVersion: caliban.caliban-ai.dev/v1alpha1
+kind: Workspace
+metadata:
+  name: team-a-ws
+  namespace: team-a
+spec:
+  displayName: Team A
+  sources:
+    - { name: caliban, repo: "git@example:caliban", ref: main, path: /work/caliban }
+  providers:
+    - name: planner
+      kind: anthropic
+      model: claude-opus-4-8
+      credentialsRef: { secretName: anthropic-key, key: api-key }
+    - name: workers
+      kind: ollama
+      baseUrl: "http://192.168.1.240:11434"
+      model: qwen2.5-coder
+  defaultProvider: planner

--- a/docs/adr/0004-workspace-crd-and-resolve-and-pin.md
+++ b/docs/adr/0004-workspace-crd-and-resolve-and-pin.md
@@ -1,0 +1,131 @@
+# ADR 0004 · `Workspace` CRD + `CalibanTask` resolve-and-pin
+
+- **Status:** accepted
+- **Date:** 2026-07-11
+- **Source:** Prospero K8s Config Plane design (umbrella design doc:
+  `docs/superpowers/plans/2026-07-11-workspace-crd-and-resolve-and-pin.md`) ·
+  caliban-operator [#11](https://github.com/caliban-ai/caliban-operator/issues/11) ·
+  epic [#274](https://github.com/caliban-ai/caliban/issues/274) · cross-repo:
+  prospero mirror (prospero#141), chart RBAC (helm-charts#30) · builds on
+  [ADR 0001](0001-kube-rs-stack-and-calibantask-crd.md)
+
+## Context
+
+[ADR 0001](0001-kube-rs-stack-and-calibantask-crd.md) put the workspace (sources,
+model/provider config) inline on `CalibanTask.spec.workspace`. Prospero's K8s Config
+Plane epic needs a UI where a user edits workspace-level config (git sources, which
+model providers are available, which Secret backs each) independently of, and prior
+to, launching any task. With the config living only inline on a `CalibanTask`,
+prospero has nowhere to persist it: there is no object to CRUD before a task exists,
+and no durable home for it once a task completes and its `CalibanTask` is deleted.
+Prospero's existing k8s-config-plane endpoint has no backing resource to write to and
+returns `405 Method Not Allowed` for exactly this reason.
+
+The epic's shape for this is explicit: prospero becomes a *pure editor of a CRD* — it
+CRUDs Kubernetes objects and lets the operator, not prospero, own reconciliation and
+credential access. That requires the config to be its own first-class,
+independently-lifecycled resource, and it requires prospero to never need Secret read
+access (the operator remains the only component that reads Secret values — a
+pre-existing, load-bearing security boundary, not a new one introduced here).
+
+Forces:
+
+- **Config must outlive any single task and be editable without one.** Sources and
+  provider bindings are workspace-scoped, shared across many `CalibanTask`s, and
+  meaningfully exist before the first task is created.
+- **Multiple named providers, not one.** A workspace may bind a cheap/local model
+  (e.g. Ollama) for routine work and a stronger hosted model (e.g. Anthropic) for
+  harder tasks; a task picks one by name at submission time, not at workspace-authoring
+  time.
+- **Prospero must never read Secrets.** Its CRUD surface is the `Workspace`/
+  `CalibanTask` specs only; `credentialsRef` carries a Secret name + key, never a
+  value, so the config plane can be edited without granting `secrets` RBAC to
+  prospero.
+- **Immutable-run guarantee must survive the split.** #283 and #366 (ADRs 0002–0003)
+  established that a running task's config is stable for its lifetime. Moving
+  provider config out of the task's own spec and into a separately-editable
+  `Workspace` must not let a config edit reach into a task that's already running.
+- **Pre-`v1alpha1` API, no migration machinery.** As in ADR 0001, `v1alpha1` buys the
+  freedom to reshape the CR without a conversion webhook; this ADR spends that budget
+  on the workspace split rather than deferring it.
+
+## Decision
+
+1. **A first-class `Workspace` CRD** (`caliban.caliban-ai.dev/v1alpha1`, namespaced,
+   status subresource, shortname `cws`) holds the durable, shared config: `sources`
+   (the git checkouts), a **named** `providers` list (each `{name, kind, baseUrl,
+   model, credentialsRef}` — a `credentialsRef` is a by-name Secret+key reference,
+   never a value), an optional `defaultProvider`, non-secret `env`, and default
+   `isolation`. `WorkspaceStatus` carries `phase` (`Pending → Reconciling → Ready |
+   Failed`), `conditions`, `observedGeneration`, and a human-readable `message`. The
+   CRD YAML is generated from the Rust types and golden-tested in sync, per ADR
+   0001's discipline.
+
+2. **A pure validation function backs a lightweight status-only reconciler.**
+   `validate_workspace(spec, secret_present: Fn(&str, &str) -> bool)` checks unique
+   provider names, a resolvable `defaultProvider`, and that every `credentialsRef`
+   names an existing Secret key — the *existence* check only. The controller supplies
+   `secret_present` by calling the Kubernetes API; **the operator is the sole reader
+   of Secret contents** in the system, unchanged from before this ADR but now made
+   structural: nothing else needs `secrets` RBAC because nothing else touches
+   `Workspace` reconciliation. The controller's only side effect is patching
+   `Workspace.status` — it creates no pods, no children; provisioning stays entirely
+   in the `CalibanTask` reconcile (ADR 0002).
+
+3. **`CalibanTask` references a `Workspace` by name and resolves-and-pins at
+   admission.** `CalibanTaskSpec` gains `workspaceRef: { name }` (required) and
+   `providerRef: Option<String>` (which named provider to bind; falls back to the
+   workspace's `defaultProvider`, then to the sole provider if there's exactly one).
+   `resolve_workspace(spec, provider_ref)` is a pure function that flattens the
+   chosen provider and the workspace's sources/env/isolation into a single
+   `ResolvedWorkspace`, erroring on a dangling `workspaceRef`/`providerRef` or an
+   ambiguous default. The `CalibanTask` reconcile calls it once and pins the result
+   into `CalibanTaskStatus.resolvedWorkspace`; if that field is already set, later
+   `Workspace` edits are **not** re-resolved into it — the pod is always built from
+   the pinned snapshot, preserving the immutable-run guarantee across the split.
+
+4. **Inline `CalibanTask.spec.workspace` is removed, not deprecated.** Per ADR 0001's
+   `v1alpha1` bet, this is a breaking, pre-v1 change with no conversion shim: existing
+   `CalibanTask` CRs must be re-created against the new schema (`workspaceRef`/
+   `providerRef`) with a companion `Workspace` applied first. There is no dual-write
+   or fallback path to the old inline shape.
+
+5. **Sample CRs are the cross-repo contract fixture.** `deploy/samples/workspace.yaml`
+   and `deploy/samples/calibantask.yaml` are committed, mutually-consistent examples
+   (the sample task's `providerRef` names a provider the sample workspace defines) and
+   are golden-tested here (`workspace::tests::sample_manifests_deserialize` — both
+   deserialize against the Rust types *and* `resolve_workspace` succeeds against
+   them). Prospero's mirror types are validated against these same fixtures
+   (prospero#141), so this is the shared fixture two repos check against
+   independently.
+
+## Consequences
+
+- **Prospero gets a durable object to edit and no path to Secrets.** Workspace
+  authoring (sources, provider bindings) no longer requires an existing task, and
+  prospero's CRUD surface never needs `secrets` RBAC — `credentialsRef` is
+  name-only. This is the change that turns the `405` from the epic's Context into a
+  real endpoint.
+- **The immutable-run guarantee is preserved, now across two objects instead of
+  one.** A running task's pod is built from `status.resolvedWorkspace`, pinned once;
+  editing the backing `Workspace` (rotating a provider, changing a source) affects
+  only tasks admitted after the edit, never one already running. This mirrors ADR
+  0002's status-derivation discipline (compute, compare, patch only on change) applied
+  to a resolve instead of a derive.
+- **This is a breaking API change with no migration.** Every existing `CalibanTask`
+  in any cluster must be replaced (`workspaceRef` + a companion `Workspace`), and
+  every caller (prospero, any manual manifests) must move off inline
+  `spec.workspace` in lockstep with this operator version. Acceptable pre-1.0 per
+  ADR 0001's `v1alpha1` bet; would not be acceptable post-graduation.
+- **The operator's own cluster RBAC needs a `Workspace`/`workspaces/status`
+  grant.** This is a small addition to the ClusterRole ADR 0002 already required for
+  `CalibanTask`; the actual chart change is cross-repo and deferred to
+  helm-charts#30, not addressed here.
+- **Multi-namespace tenancy remains deferred.** `workspaceRef` is a same-namespace,
+  by-name reference (mirroring `WorkspaceRef`'s single `name` field); a
+  `CalibanTask` cannot bind to a `Workspace` in another namespace. Cross-namespace
+  workspace sharing, if ever needed, is a later ADR.
+- **Prospero's mirror types can rot independently of this repo.** The sample CRs
+  are the shared contract, but there is no compile-time link between this repo's
+  Rust types and prospero's — a schema change here that isn't reflected in
+  prospero#141's mirror surfaces only at prospero's own test run, not here.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,3 +12,4 @@ history.
 | [0001](0001-kube-rs-stack-and-calibantask-crd.md) | kube-rs stack + `CalibanTask` CRD API (`caliban.caliban-ai.dev/v1alpha1`, namespaced, status subresource; generated CRD YAML) | accepted |
 | [0002](0002-reconcile-calibantask-to-sandbox.md) | Reconcile `CalibanTask` → agent-sandbox `Sandbox` (+ per-task token-less SA & default-deny NetworkPolicy; foreign `Sandbox` type; SSA + owner refs; status from `serviceFQDN`) | accepted |
 | [0003](0003-caliband-launch-contract.md) | The caliband launch contract — daemon `args` (`--workspace-root`/`--listen`), git-clone init container for the workspace, plaintext TCP for the first e2e | accepted |
+| [0004](0004-workspace-crd-and-resolve-and-pin.md) | `Workspace` CRD (named providers, operator-sole-Secret-reader) + `CalibanTask` `workspaceRef`/`providerRef` resolve-and-pin; inline `spec.workspace` removed (pre-v1 breaking) | accepted |

--- a/docs/superpowers/plans/2026-07-11-workspace-crd-and-resolve-and-pin.md
+++ b/docs/superpowers/plans/2026-07-11-workspace-crd-and-resolve-and-pin.md
@@ -1,0 +1,1322 @@
+# Workspace CRD + resolve-and-pin Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce a first-class `Workspace` CRD with a validation/status reconciler, and switch `CalibanTask` from an inline `spec.workspace` to `workspaceRef`/`providerRef` that the operator resolves and pins at admission — the operator-side foundation (change set B) of the Prospero K8s Config Plane epic (caliban-operator#11).
+
+**Architecture:** A new `Workspace` CRD (`caliban.caliban-ai.dev/v1alpha1`) holds the durable, shared config — `sources[]`, a **named** `providers[]` list (each with its own model + Secret reference), default provider, env, isolation. A lightweight controller validates it (the operator is the *only* component that reads Secrets) and writes `status.phase`. `CalibanTask` now references a `Workspace` by name plus an optional `providerRef`; its controller resolves both at admission, pins the resolved config into `status.resolvedWorkspace` (immutable-run guarantee), and builds the pod from that pinned config. Inline `CalibanTask.spec.workspace` is removed (pre-v1, no back-compat).
+
+**Tech Stack:** Rust 2021 (toolchain 1.95.0), `kube` 4.0 (runtime/derive/client), `k8s-openapi` v1_32, `schemars` 1.2, `serde`/`serde_json`, `serde_norway` (CRD YAML), `tokio`, `thiserror`, `tracing`. Tests are pure-function unit tests + golden CRD serialization (the repo's established `derive_status` pattern) — no live cluster in CI.
+
+## Global Constraints
+
+- **Group/version:** `caliban.caliban-ai.dev/v1alpha1`, namespaced, for both CRDs. Verbatim.
+- **CRD field casing:** all spec/status JSON is `camelCase` (`#[serde(rename_all = "camelCase")]` on every struct), matching the existing `CalibanTask`.
+- **Secret boundary:** the operator is the **only** component that reads Secret values. Workspace validation checks *existence* of `credentialsRef` (secretName+key); provider credentials reach the pod via `EnvVar.valueFrom.secretKeyRef` (never inlined into the CR or the operator's memory).
+- **Pinned-at-admission / immutable run:** once a `CalibanTask` has a non-empty `status.resolvedWorkspace`, later `Workspace` edits must NOT re-pin it. New tasks pick up current config.
+- **No back-compat:** inline `CalibanTask.spec.workspace` is removed; existing cluster CRs are re-created under the new schema. No deprecation shim.
+- **CRD YAML is generated + golden-tested:** every schema change requires regenerating `deploy/crd/*.yaml` (`cargo run --bin crdgen <kind>`); the `*_is_in_sync` tests guard drift. Never hand-edit the committed YAML.
+- **CI gate (mirrors `.github/workflows/ci.yml`):** `cargo fmt --all -- --check` · `cargo clippy --workspace --all-targets -- -D warnings` · `cargo build --workspace --all-targets` · `cargo test --workspace`. All four must pass.
+
+---
+
+## File Structure
+
+- `src/workspace.rs` **(new)** — the `Workspace` CRD (`WorkspaceSpec`, `Provider`, `CredentialsRef`, `EnvEntry`, `WorkspaceStatus`, `WorkspacePhase`, `Workspace` via `CustomResource`), the resolved-config value types (`ResolvedWorkspace`, `ResolvedProvider`), and the two pure functions `validate_workspace()` and `resolve_workspace()`. Uses `crate::crd::{Source, IsolationSpec, Condition}` (same-crate cross-reference — Rust allows it).
+- `src/workspace_controller.rs` **(new)** — the `Workspace` controller: fetches referenced Secrets, builds a `secret_present` closure, calls `validate_workspace`, patches `Workspace/status`. Exposes `run(Client) -> anyhow::Result<()>`.
+- `src/crd.rs` **(modify)** — `CalibanTaskSpec` loses `workspace`, gains `workspace_ref: WorkspaceRef`, `provider_ref: Option<String>`, `tools: Option<Vec<String>>`; new `WorkspaceRef` struct; `CalibanTaskStatus` gains `resolved_workspace: Option<ResolvedWorkspace>`. The `Workspace` struct (inline aux) is deleted; `Source`/`IsolationSpec`/`Condition` stay here as shared value types.
+- `src/resources.rs` **(modify)** — builders consume `&ResolvedWorkspace` (sources + provider env) instead of `t.spec.workspace`; new provider-env projection with `secretKeyRef`. `plan(t, resolved, s)`.
+- `src/controller.rs` **(modify)** — CalibanTask reconcile fetches the `Workspace`, resolves + pins into `status.resolvedWorkspace` (once), fails fast on a dangling/invalid ref, feeds the resolved config into `plan`.
+- `src/lib.rs` **(modify)** — add `pub mod workspace; pub mod workspace_controller;` and re-exports.
+- `src/bin/crdgen.rs` **(modify)** — take a positional `<kind>` arg (`calibantask` | `workspace`) and print that CRD.
+- `src/bin/caliban-operator.rs` **(modify)** — run the CalibanTask and Workspace controllers concurrently.
+- `deploy/crd/workspace.yaml` **(new, generated)** · `deploy/crd/calibantask.yaml` **(regenerated)**.
+- `deploy/samples/workspace.yaml` + `deploy/samples/calibantask.yaml` **(new)** — the cross-repo contract fixtures prospero's mirror validates against.
+- `docs/adr/0004-workspace-crd-and-resolve-and-pin.md` **(new)** — records the decision; index row in `docs/adr/README.md`.
+
+---
+
+## Task 1: Workspace CRD types + golden YAML
+
+**Files:**
+- Create: `src/workspace.rs`
+- Modify: `src/lib.rs`, `src/bin/crdgen.rs`
+- Create: `deploy/crd/workspace.yaml`
+- Test: inline `#[cfg(test)]` in `src/workspace.rs`
+
+**Interfaces:**
+- Produces: `Workspace` (CRD, `caliban.caliban-ai.dev/v1alpha1`), `WorkspaceSpec { display_name: String, sources: Vec<crd::Source>, providers: Vec<Provider>, default_provider: Option<String>, env: Vec<EnvEntry>, isolation: Option<crd::IsolationSpec> }`, `Provider { name: String, kind: String, base_url: Option<String>, model: Option<String>, credentials_ref: Option<CredentialsRef> }`, `CredentialsRef { secret_name: String, key: String }`, `EnvEntry { name: String, value: String }`, `WorkspaceStatus { phase: WorkspacePhase, conditions: Vec<crd::Condition>, observed_generation: Option<i64>, message: Option<String> }`, `WorkspacePhase { Pending, Reconciling, Ready, Failed }` (Default = `Pending`).
+
+- [ ] **Step 1: Add the module declarations**
+
+In `src/lib.rs`, after `pub mod sandbox;` add:
+
+```rust
+pub mod workspace;
+pub mod workspace_controller;
+```
+
+And extend the re-export line:
+
+```rust
+pub use crd::{CalibanTask, CalibanTaskSpec, CalibanTaskStatus, Phase};
+pub use workspace::{Workspace, WorkspaceSpec, WorkspaceStatus};
+```
+
+(`workspace_controller` is created in Task 3; add a temporary empty file now so the crate compiles: `echo '//! placeholder' > src/workspace_controller.rs`.)
+
+- [ ] **Step 2: Write the Workspace CRD types**
+
+Create `src/workspace.rs` with the type definitions (no tests yet):
+
+```rust
+//! The `Workspace` custom resource (v1alpha1): durable, shared config — sources,
+//! named providers (each with its own model + Secret reference), env, isolation —
+//! that `CalibanTask`s reference by name. Owned and reconciled by the operator,
+//! which is the sole reader of provider credential Secrets. See ADR 0004 and the
+//! Prospero K8s Config Plane design.
+
+use kube::CustomResource;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::crd::{Condition, IsolationSpec, Source};
+
+/// Desired state of a workspace: sources + named providers + defaults.
+#[derive(CustomResource, Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[kube(
+    group = "caliban.caliban-ai.dev",
+    version = "v1alpha1",
+    kind = "Workspace",
+    namespaced,
+    status = "WorkspaceStatus",
+    shortname = "cws",
+    printcolumn = r#"{"name":"Phase","type":"string","jsonPath":".status.phase"}"#,
+    printcolumn = r#"{"name":"Age","type":"date","jsonPath":".metadata.creationTimestamp"}"#
+)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceSpec {
+    /// Human-friendly dashboard label.
+    #[schemars(length(min = 1))]
+    pub display_name: String,
+    /// The workspace's git checkouts (1..N).
+    #[schemars(length(min = 1))]
+    pub sources: Vec<Source>,
+    /// Named providers (1..N) agents in this workspace can bind to.
+    #[schemars(length(min = 1))]
+    pub providers: Vec<Provider>,
+    /// Provider name agents get when they don't request one. Implicit when
+    /// exactly one provider is defined.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_provider: Option<String>,
+    /// Non-secret environment injected into every agent pod.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<EnvEntry>,
+    /// Default isolation for agents launched against this workspace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isolation: Option<IsolationSpec>,
+}
+
+/// A named model provider bound within a workspace.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Provider {
+    /// Provider identifier, unique within the workspace (e.g. `planner`).
+    #[schemars(length(min = 1))]
+    pub name: String,
+    /// Provider kind (e.g. `ollama`, `anthropic`, `openai`).
+    #[schemars(length(min = 1))]
+    pub kind: String,
+    /// Override base URL (e.g. `http://192.168.1.240:11434`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+    /// Default model for this provider.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Reference to an existing Secret for this provider's API key. Keyless
+    /// providers (e.g. ollama) omit it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credentials_ref: Option<CredentialsRef>,
+}
+
+/// A by-name reference to a key within an existing Kubernetes Secret.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialsRef {
+    /// Name of the Secret (same namespace).
+    #[schemars(length(min = 1))]
+    pub secret_name: String,
+    /// Key within the Secret's data.
+    #[schemars(length(min = 1))]
+    pub key: String,
+}
+
+/// A non-secret environment entry.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct EnvEntry {
+    /// Variable name.
+    #[schemars(length(min = 1))]
+    pub name: String,
+    /// Variable value.
+    pub value: String,
+}
+
+/// Observed state of a `Workspace`.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceStatus {
+    /// Lifecycle phase.
+    #[serde(default)]
+    pub phase: WorkspacePhase,
+    /// Standard Kubernetes conditions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub conditions: Vec<Condition>,
+    /// The `.metadata.generation` this status reflects.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_generation: Option<i64>,
+    /// Human-readable detail (e.g. `provider 'planner': secret 'anthropic-key' not found`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+/// `Workspace` lifecycle phase.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq, JsonSchema)]
+pub enum WorkspacePhase {
+    /// Created, not yet reconciled.
+    #[default]
+    Pending,
+    /// Reconcile in progress.
+    Reconciling,
+    /// Valid — all providers and credential Secrets resolve.
+    Ready,
+    /// Invalid — see `message`.
+    Failed,
+}
+```
+
+- [ ] **Step 3: Write the golden CRD serialization tests**
+
+Append to `src/workspace.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kube::CustomResourceExt;
+
+    #[test]
+    fn crd_has_correct_group_version_kind() {
+        let crd = Workspace::crd();
+        assert_eq!(crd.spec.group, "caliban.caliban-ai.dev");
+        assert_eq!(crd.spec.names.kind, "Workspace");
+        assert_eq!(crd.spec.versions[0].name, "v1alpha1");
+        assert_eq!(crd.spec.scope, "Namespaced");
+        assert!(crd.spec.versions[0]
+            .subresources
+            .as_ref()
+            .unwrap()
+            .status
+            .is_some());
+    }
+
+    #[test]
+    fn crd_enforces_non_empty_required_fields() {
+        let crd = Workspace::crd();
+        let schema = serde_json::to_value(&crd.spec.versions[0].schema).unwrap();
+        let spec = &schema["openAPIV3Schema"]["properties"]["spec"]["properties"];
+        assert_eq!(spec["sources"]["minItems"], 1);
+        assert_eq!(spec["providers"]["minItems"], 1);
+        assert_eq!(spec["displayName"]["minLength"], 1);
+        let prov = &spec["providers"]["items"]["properties"];
+        assert_eq!(prov["name"]["minLength"], 1);
+        assert_eq!(prov["kind"]["minLength"], 1);
+    }
+
+    #[test]
+    fn sample_cr_round_trips() {
+        let yaml = r#"
+apiVersion: caliban.caliban-ai.dev/v1alpha1
+kind: Workspace
+metadata: { name: team-a-ws, namespace: team-a }
+spec:
+  displayName: Team A
+  sources:
+    - { name: caliban, repo: "git@example:caliban", ref: main, path: /work/caliban }
+  providers:
+    - { name: planner, kind: anthropic, model: claude-opus-4-8, credentialsRef: { secretName: anthropic-key, key: api-key } }
+    - { name: workers, kind: ollama, baseUrl: "http://192.168.1.240:11434", model: qwen2.5-coder }
+  defaultProvider: planner
+"#;
+        let ws: Workspace = serde_norway::from_str(yaml).unwrap();
+        assert_eq!(ws.spec.providers.len(), 2);
+        assert_eq!(ws.spec.providers[0].name, "planner");
+        assert_eq!(
+            ws.spec.providers[0]
+                .credentials_ref
+                .as_ref()
+                .unwrap()
+                .secret_name,
+            "anthropic-key"
+        );
+        assert!(ws.spec.providers[1].credentials_ref.is_none());
+        assert_eq!(ws.spec.default_provider.as_deref(), Some("planner"));
+        // camelCase survives round-trip.
+        let v = serde_json::to_value(&ws.spec).unwrap();
+        assert!(v["displayName"].is_string());
+    }
+
+    #[test]
+    fn committed_crd_yaml_is_in_sync() {
+        let generated = serde_norway::to_string(&Workspace::crd()).unwrap();
+        let committed = include_str!("../deploy/crd/workspace.yaml");
+        assert_eq!(
+            generated.trim(),
+            committed.trim(),
+            "deploy/crd/workspace.yaml is stale — regenerate: cargo run --bin crdgen workspace > deploy/crd/workspace.yaml"
+        );
+    }
+}
+```
+
+- [ ] **Step 4: Run the type/round-trip tests (sync test will fail — expected)**
+
+Run: `cargo test -p caliban-operator workspace::tests::sample_cr_round_trips workspace::tests::crd_has_correct_group_version_kind workspace::tests::crd_enforces_non_empty_required_fields`
+Expected: PASS (these three don't need the committed YAML).
+
+- [ ] **Step 5: Teach `crdgen` to emit either CRD, then generate `workspace.yaml`**
+
+Replace `src/bin/crdgen.rs` with:
+
+```rust
+//! Emit a CRD's YAML: `cargo run --bin crdgen <calibantask|workspace> > deploy/crd/<kind>.yaml`.
+
+use kube::CustomResourceExt;
+
+fn main() -> anyhow::Result<()> {
+    let kind = std::env::args().nth(1).unwrap_or_else(|| "calibantask".into());
+    let yaml = match kind.as_str() {
+        "calibantask" => serde_norway::to_string(&caliban_operator::crd::CalibanTask::crd())?,
+        "workspace" => serde_norway::to_string(&caliban_operator::workspace::Workspace::crd())?,
+        other => anyhow::bail!("unknown CRD kind {other:?}; expected calibantask|workspace"),
+    };
+    print!("{yaml}");
+    Ok(())
+}
+```
+
+Then generate the manifest:
+
+```bash
+cargo run --quiet --bin crdgen workspace > deploy/crd/workspace.yaml
+```
+
+- [ ] **Step 6: Run the full sync test**
+
+Run: `cargo test -p caliban-operator workspace::tests`
+Expected: PASS (all four, including `committed_crd_yaml_is_in_sync`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib.rs src/workspace.rs src/workspace_controller.rs src/bin/crdgen.rs deploy/crd/workspace.yaml
+git commit -m "feat(crd): add Workspace CRD (v1alpha1) + crdgen kind selector (#11)"
+```
+
+---
+
+## Task 2: `validate_workspace()` — pure validation
+
+**Files:**
+- Modify: `src/workspace.rs`
+- Test: inline `#[cfg(test)]` in `src/workspace.rs`
+
+**Interfaces:**
+- Consumes: `WorkspaceSpec`, `Provider`, `CredentialsRef` (Task 1).
+- Produces: `WorkspaceValidation { phase: WorkspacePhase, message: Option<String> }` and `pub fn validate_workspace(spec: &WorkspaceSpec, secret_present: impl Fn(&str, &str) -> bool) -> WorkspaceValidation`. `secret_present(secret_name, key)` returns whether that Secret key exists. Cluster access is the caller's job (Task 3) — this function is pure and unit-tested.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `tests` module in `src/workspace.rs`:
+
+```rust
+    fn spec_with(providers: Vec<Provider>, default_provider: Option<&str>) -> WorkspaceSpec {
+        WorkspaceSpec {
+            display_name: "Team A".into(),
+            sources: vec![Source {
+                name: "caliban".into(),
+                repo: "git@x:caliban".into(),
+                r#ref: "main".into(),
+                path: "/work/caliban".into(),
+            }],
+            providers,
+            default_provider: default_provider.map(String::from),
+            env: vec![],
+            isolation: None,
+        }
+    }
+
+    fn provider(name: &str, cred: Option<(&str, &str)>) -> Provider {
+        Provider {
+            name: name.into(),
+            kind: "anthropic".into(),
+            base_url: None,
+            model: None,
+            credentials_ref: cred.map(|(s, k)| CredentialsRef {
+                secret_name: s.into(),
+                key: k.into(),
+            }),
+        }
+    }
+
+    #[test]
+    fn valid_workspace_is_ready() {
+        let spec = spec_with(vec![provider("planner", Some(("anthropic-key", "api-key")))], Some("planner"));
+        let v = validate_workspace(&spec, |s, k| s == "anthropic-key" && k == "api-key");
+        assert_eq!(v.phase, WorkspacePhase::Ready);
+        assert!(v.message.is_none());
+    }
+
+    #[test]
+    fn keyless_provider_needs_no_secret() {
+        let mut p = provider("workers", None);
+        p.kind = "ollama".into();
+        let spec = spec_with(vec![p], None);
+        let v = validate_workspace(&spec, |_, _| false); // no secrets exist at all
+        assert_eq!(v.phase, WorkspacePhase::Ready);
+    }
+
+    #[test]
+    fn missing_secret_fails_with_message() {
+        let spec = spec_with(vec![provider("planner", Some(("anthropic-key", "api-key")))], None);
+        let v = validate_workspace(&spec, |_, _| false);
+        assert_eq!(v.phase, WorkspacePhase::Failed);
+        assert_eq!(
+            v.message.as_deref(),
+            Some("provider 'planner': secret 'anthropic-key' key 'api-key' not found")
+        );
+    }
+
+    #[test]
+    fn duplicate_provider_names_fail() {
+        let spec = spec_with(vec![provider("planner", None), provider("planner", None)], None);
+        let v = validate_workspace(&spec, |_, _| true);
+        assert_eq!(v.phase, WorkspacePhase::Failed);
+        assert_eq!(v.message.as_deref(), Some("duplicate provider name 'planner'"));
+    }
+
+    #[test]
+    fn dangling_default_provider_fails() {
+        let spec = spec_with(vec![provider("planner", None)], Some("nope"));
+        let v = validate_workspace(&spec, |_, _| true);
+        assert_eq!(v.phase, WorkspacePhase::Failed);
+        assert_eq!(v.message.as_deref(), Some("defaultProvider 'nope' names no provider"));
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p caliban-operator workspace::tests::valid_workspace_is_ready`
+Expected: FAIL with "cannot find function `validate_workspace`".
+
+- [ ] **Step 3: Implement `validate_workspace`**
+
+Add to `src/workspace.rs` (above the `tests` module):
+
+```rust
+/// Outcome of validating a `Workspace` against known Secret existence.
+pub struct WorkspaceValidation {
+    /// Derived phase (`Ready` or `Failed`).
+    pub phase: WorkspacePhase,
+    /// Human-readable failure detail, `None` when `Ready`.
+    pub message: Option<String>,
+}
+
+/// Pure validation of a `WorkspaceSpec`: unique provider names, a resolvable
+/// `defaultProvider`, and an existing Secret key for every `credentialsRef`.
+/// `secret_present(secret_name, key)` reports Secret-key existence (cluster
+/// lookup is the caller's responsibility). First problem found wins.
+pub fn validate_workspace(
+    spec: &WorkspaceSpec,
+    secret_present: impl Fn(&str, &str) -> bool,
+) -> WorkspaceValidation {
+    fn failed(message: String) -> WorkspaceValidation {
+        WorkspaceValidation {
+            phase: WorkspacePhase::Failed,
+            message: Some(message),
+        }
+    }
+
+    let mut seen = std::collections::BTreeSet::new();
+    for p in &spec.providers {
+        if !seen.insert(p.name.as_str()) {
+            return failed(format!("duplicate provider name '{}'", p.name));
+        }
+    }
+    if let Some(dp) = &spec.default_provider {
+        if !spec.providers.iter().any(|p| &p.name == dp) {
+            return failed(format!("defaultProvider '{dp}' names no provider"));
+        }
+    }
+    for p in &spec.providers {
+        if let Some(c) = &p.credentials_ref {
+            if !secret_present(&c.secret_name, &c.key) {
+                return failed(format!(
+                    "provider '{}': secret '{}' key '{}' not found",
+                    p.name, c.secret_name, c.key
+                ));
+            }
+        }
+    }
+    WorkspaceValidation {
+        phase: WorkspacePhase::Ready,
+        message: None,
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cargo test -p caliban-operator workspace::tests`
+Expected: PASS (all validation tests + the Task 1 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/workspace.rs
+git commit -m "feat(workspace): pure validate_workspace (provider/secret checks) (#11)"
+```
+
+---
+
+## Task 3: Workspace controller + dual-controller run wiring
+
+**Files:**
+- Modify: `src/workspace_controller.rs` (replace the placeholder)
+- Modify: `src/bin/caliban-operator.rs`
+- Test: inline `#[cfg(test)]` in `src/workspace_controller.rs`
+
+**Interfaces:**
+- Consumes: `Workspace`, `WorkspaceStatus`, `WorkspacePhase`, `validate_workspace` (Tasks 1–2).
+- Produces: `pub async fn run(client: Client) -> anyhow::Result<()>` and `pub(crate) fn derive_workspace_status(ws: &Workspace, v: WorkspaceValidation) -> Option<WorkspaceStatus>` (returns `Some` only when status changed — the no-op-churn pattern from `controller::derive_status`).
+
+- [ ] **Step 1: Write the failing test for `derive_workspace_status`**
+
+Create `src/workspace_controller.rs`:
+
+```rust
+//! The `Workspace` controller: validates each `Workspace` (the operator is the
+//! sole Secret reader) and writes `status.phase` / `message` /
+//! `observedGeneration`. Provisions nothing. See ADR 0004.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt as _;
+use k8s_openapi::api::core::v1::Secret;
+use kube::api::{Patch, PatchParams};
+use kube::runtime::controller::Action;
+use kube::runtime::watcher::Config;
+use kube::runtime::Controller;
+use kube::{Api, Client, ResourceExt};
+
+use crate::workspace::{
+    validate_workspace, Workspace, WorkspacePhase, WorkspaceStatus, WorkspaceValidation,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crd::Source;
+    use crate::workspace::{Provider, WorkspaceSpec};
+
+    fn workspace(gen: i64) -> Workspace {
+        let mut ws = Workspace::new(
+            "team-a-ws",
+            WorkspaceSpec {
+                display_name: "Team A".into(),
+                sources: vec![Source {
+                    name: "caliban".into(),
+                    repo: "git@x:caliban".into(),
+                    r#ref: "main".into(),
+                    path: "/work/caliban".into(),
+                }],
+                providers: vec![Provider {
+                    name: "workers".into(),
+                    kind: "ollama".into(),
+                    base_url: None,
+                    model: None,
+                    credentials_ref: None,
+                }],
+                default_provider: None,
+                env: vec![],
+                isolation: None,
+            },
+        );
+        ws.metadata.namespace = Some("team-a".into());
+        ws.metadata.generation = Some(gen);
+        ws
+    }
+
+    #[test]
+    fn ready_status_is_derived_and_records_generation() {
+        let ws = workspace(3);
+        let v = validate_workspace(&ws.spec, |_, _| true);
+        let s = derive_workspace_status(&ws, v).unwrap();
+        assert_eq!(s.phase, WorkspacePhase::Ready);
+        assert_eq!(s.observed_generation, Some(3));
+        assert!(s.message.is_none());
+    }
+
+    #[test]
+    fn unchanged_status_is_noop() {
+        let mut ws = workspace(3);
+        let v = validate_workspace(&ws.spec, |_, _| true);
+        ws.status = derive_workspace_status(&ws, v);
+        let v2 = validate_workspace(&ws.spec, |_, _| true);
+        assert!(derive_workspace_status(&ws, v2).is_none());
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p caliban-operator workspace_controller::tests::ready_status_is_derived_and_records_generation`
+Expected: FAIL with "cannot find function `derive_workspace_status`".
+
+- [ ] **Step 3: Implement the controller + `derive_workspace_status`**
+
+Insert above the `tests` module in `src/workspace_controller.rs`:
+
+```rust
+/// Controller error.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// Kubernetes API error.
+    #[error("kube api: {0}")]
+    Kube(#[from] kube::Error),
+    /// Status serialization error.
+    #[error("serialize status: {0}")]
+    Serialize(#[from] serde_json::Error),
+}
+
+/// Derive the new `WorkspaceStatus` from a validation result. Returns `Some`
+/// only when it differs from the observed status (no-op-churn avoidance,
+/// mirroring `controller::derive_status`).
+pub(crate) fn derive_workspace_status(
+    ws: &Workspace,
+    v: WorkspaceValidation,
+) -> Option<WorkspaceStatus> {
+    let mut next = ws.status.clone().unwrap_or_default();
+    next.phase = v.phase;
+    next.message = v.message;
+    next.observed_generation = ws.metadata.generation;
+    match &ws.status {
+        Some(cur)
+            if cur.phase == next.phase
+                && cur.message == next.message
+                && cur.observed_generation == next.observed_generation =>
+        {
+            None
+        }
+        _ => Some(next),
+    }
+}
+
+async fn reconcile(ws: Arc<Workspace>, ctx: Arc<Client>) -> Result<Action, Error> {
+    let ns = ws.namespace().unwrap_or_default();
+    let name = ws.name_any();
+    let secrets: Api<Secret> = Api::namespaced((*ctx).clone(), &ns);
+
+    // Resolve which (secretName, key) pairs actually exist, once, up front, so
+    // validate_workspace stays pure.
+    let mut present: std::collections::BTreeSet<(String, String)> = Default::default();
+    for p in &ws.spec.providers {
+        if let Some(c) = &p.credentials_ref {
+            if let Some(sec) = secrets.get_opt(&c.secret_name).await? {
+                let has = sec
+                    .data
+                    .as_ref()
+                    .is_some_and(|d| d.contains_key(&c.key))
+                    || sec
+                        .string_data
+                        .as_ref()
+                        .is_some_and(|d| d.contains_key(&c.key));
+                if has {
+                    present.insert((c.secret_name.clone(), c.key.clone()));
+                }
+            }
+        }
+    }
+    let validation = validate_workspace(&ws.spec, |s, k| {
+        present.contains(&(s.to_string(), k.to_string()))
+    });
+
+    if let Some(status) = derive_workspace_status(&ws, validation) {
+        let api: Api<Workspace> = Api::namespaced((*ctx).clone(), &ns);
+        let phase = status.phase;
+        let patch = serde_json::json!({ "status": status });
+        api.patch_status(&name, &PatchParams::default(), &Patch::Merge(&patch))
+            .await?;
+        tracing::info!(%ns, %name, ?phase, "patched Workspace status");
+    }
+    Ok(Action::requeue(Duration::from_secs(300)))
+}
+
+fn error_policy(_ws: Arc<Workspace>, err: &Error, _ctx: Arc<Client>) -> Action {
+    tracing::warn!(error = %err, "workspace reconcile error");
+    Action::requeue(Duration::from_secs(30))
+}
+
+/// Run the Workspace controller until shutdown.
+pub async fn run(client: Client) -> anyhow::Result<()> {
+    let workspaces: Api<Workspace> = Api::all(client.clone());
+    let ctx = Arc::new(client);
+    Controller::new(workspaces, Config::default())
+        .shutdown_on_signal()
+        .run(reconcile, error_policy, ctx)
+        .for_each(|res| async move {
+            match res {
+                Ok((obj, _)) => tracing::debug!(?obj, "workspace reconciled"),
+                Err(e) => tracing::warn!(error = %e, "workspace controller error"),
+            }
+        })
+        .await;
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run to verify the tests pass**
+
+Run: `cargo test -p caliban-operator workspace_controller::tests`
+Expected: PASS.
+
+- [ ] **Step 5: Run both controllers concurrently from the entrypoint**
+
+Replace the body of `main` in `src/bin/caliban-operator.rs` (after the client is built) so both controllers run together:
+
+```rust
+    let client = kube::Client::try_default().await?;
+    tracing::info!("connected to the Kubernetes API");
+    tokio::try_join!(
+        caliban_operator::controller::run(client.clone()),
+        caliban_operator::workspace_controller::run(client),
+    )?;
+    Ok(())
+```
+
+- [ ] **Step 6: Build to confirm the entrypoint compiles**
+
+Run: `cargo build --workspace --all-targets`
+Expected: builds clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/workspace_controller.rs src/bin/caliban-operator.rs
+git commit -m "feat(workspace): validation/status controller + run both controllers (#11)"
+```
+
+---
+
+## Task 4: Resolved-config types + `resolve_workspace()` — pure resolve
+
+**Files:**
+- Modify: `src/workspace.rs`
+- Test: inline `#[cfg(test)]` in `src/workspace.rs`
+
+**Interfaces:**
+- Consumes: `WorkspaceSpec`, `Provider` (Task 1).
+- Produces: `ResolvedProvider { name, kind, base_url: Option<String>, model: Option<String>, credentials_ref: Option<CredentialsRef> }`, `ResolvedWorkspace { sources: Vec<crd::Source>, provider: ResolvedProvider, env: Vec<EnvEntry>, isolation: Option<crd::IsolationSpec> }`, and `pub fn resolve_workspace(spec: &WorkspaceSpec, provider_ref: Option<&str>) -> Result<ResolvedWorkspace, String>`. Both resolved types derive `Serialize, Deserialize, Clone, Debug, JsonSchema` (they are pinned into `CalibanTaskStatus`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to the `tests` module in `src/workspace.rs`:
+
+```rust
+    #[test]
+    fn resolve_picks_named_provider() {
+        let spec = spec_with(
+            vec![provider("planner", Some(("k", "v"))), provider("workers", None)],
+            Some("planner"),
+        );
+        let r = resolve_workspace(&spec, Some("workers")).unwrap();
+        assert_eq!(r.provider.name, "workers");
+        assert_eq!(r.sources.len(), 1);
+    }
+
+    #[test]
+    fn resolve_falls_back_to_default_provider() {
+        let spec = spec_with(vec![provider("planner", None), provider("workers", None)], Some("workers"));
+        let r = resolve_workspace(&spec, None).unwrap();
+        assert_eq!(r.provider.name, "workers");
+    }
+
+    #[test]
+    fn resolve_uses_sole_provider_when_no_default() {
+        let spec = spec_with(vec![provider("only", None)], None);
+        let r = resolve_workspace(&spec, None).unwrap();
+        assert_eq!(r.provider.name, "only");
+    }
+
+    #[test]
+    fn resolve_ambiguous_without_default_errors() {
+        let spec = spec_with(vec![provider("a", None), provider("b", None)], None);
+        let err = resolve_workspace(&spec, None).unwrap_err();
+        assert_eq!(err, "no providerRef and workspace has no defaultProvider among 2 providers");
+    }
+
+    #[test]
+    fn resolve_dangling_provider_ref_errors() {
+        let spec = spec_with(vec![provider("planner", None)], None);
+        let err = resolve_workspace(&spec, Some("nope")).unwrap_err();
+        assert_eq!(err, "providerRef 'nope' names no provider in the workspace");
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p caliban-operator workspace::tests::resolve_picks_named_provider`
+Expected: FAIL with "cannot find function `resolve_workspace`".
+
+- [ ] **Step 3: Implement the resolved types + `resolve_workspace`**
+
+Add to `src/workspace.rs` (above the `tests` module):
+
+```rust
+/// A provider with its workspace context flattened in — the pinned form.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolvedProvider {
+    /// Provider name.
+    pub name: String,
+    /// Provider kind.
+    pub kind: String,
+    /// Base URL, if set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+    /// Model, if set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Credential Secret reference, if the provider needs one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credentials_ref: Option<CredentialsRef>,
+}
+
+/// The workspace config a `CalibanTask` runs against, resolved to a single
+/// provider and pinned into `CalibanTaskStatus.resolvedWorkspace` at admission.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolvedWorkspace {
+    /// The workspace's source checkouts.
+    pub sources: Vec<Source>,
+    /// The single provider this task binds to.
+    pub provider: ResolvedProvider,
+    /// Non-secret env from the workspace.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<EnvEntry>,
+    /// Workspace default isolation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isolation: Option<IsolationSpec>,
+}
+
+/// Resolve a `WorkspaceSpec` + optional `providerRef` to a single-provider
+/// `ResolvedWorkspace`. Provider selection: explicit `provider_ref` →
+/// `defaultProvider` → the sole provider if there's exactly one. Errors on a
+/// dangling ref or an ambiguous choice.
+pub fn resolve_workspace(
+    spec: &WorkspaceSpec,
+    provider_ref: Option<&str>,
+) -> Result<ResolvedWorkspace, String> {
+    let chosen = match provider_ref {
+        Some(name) => spec
+            .providers
+            .iter()
+            .find(|p| p.name == name)
+            .ok_or_else(|| format!("providerRef '{name}' names no provider in the workspace"))?,
+        None => match &spec.default_provider {
+            Some(dp) => spec
+                .providers
+                .iter()
+                .find(|p| &p.name == dp)
+                .ok_or_else(|| format!("defaultProvider '{dp}' names no provider"))?,
+            None if spec.providers.len() == 1 => &spec.providers[0],
+            None => {
+                return Err(format!(
+                    "no providerRef and workspace has no defaultProvider among {} providers",
+                    spec.providers.len()
+                ))
+            }
+        },
+    };
+    Ok(ResolvedWorkspace {
+        sources: spec.sources.clone(),
+        provider: ResolvedProvider {
+            name: chosen.name.clone(),
+            kind: chosen.kind.clone(),
+            base_url: chosen.base_url.clone(),
+            model: chosen.model.clone(),
+            credentials_ref: chosen.credentials_ref.clone(),
+        },
+        env: spec.env.clone(),
+        isolation: spec.isolation.clone(),
+    })
+}
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cargo test -p caliban-operator workspace::tests`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/workspace.rs
+git commit -m "feat(workspace): ResolvedWorkspace + resolve_workspace provider selection (#11)"
+```
+
+---
+
+## Task 5: Provider env projection (with `secretKeyRef`)
+
+**Files:**
+- Modify: `src/resources.rs`
+- Test: inline `#[cfg(test)]` in `src/resources.rs`
+
+**Interfaces:**
+- Consumes: `ResolvedProvider`, `EnvEntry` (Task 4).
+- Produces: `pub(crate) fn provider_env(rp: &ResolvedProvider) -> Vec<EnvVar>` — projects a resolved provider to caliband env: `CALIBAN_PROVIDER=<kind>`; `CALIBAN_PROVIDER_BASE_URL=<baseUrl>` if set; `CALIBAN_MODEL=<model>` if set; and, when `credentials_ref` is set, `CALIBAN_API_KEY` via `valueFrom.secretKeyRef` (the operator never inlines the value).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module in `src/resources.rs`:
+
+```rust
+    #[test]
+    fn provider_env_projects_kind_url_model_and_secret_ref() {
+        use crate::workspace::{CredentialsRef, ResolvedProvider};
+        let rp = ResolvedProvider {
+            name: "planner".into(),
+            kind: "anthropic".into(),
+            base_url: Some("https://api.anthropic.com".into()),
+            model: Some("claude-opus-4-8".into()),
+            credentials_ref: Some(CredentialsRef {
+                secret_name: "anthropic-key".into(),
+                key: "api-key".into(),
+            }),
+        };
+        let env = provider_env(&rp);
+        let get = |n: &str| env.iter().find(|e| e.name == n).cloned();
+        assert_eq!(get("CALIBAN_PROVIDER").unwrap().value.as_deref(), Some("anthropic"));
+        assert_eq!(
+            get("CALIBAN_PROVIDER_BASE_URL").unwrap().value.as_deref(),
+            Some("https://api.anthropic.com")
+        );
+        assert_eq!(get("CALIBAN_MODEL").unwrap().value.as_deref(), Some("claude-opus-4-8"));
+        // Secret reaches the pod by reference, never inlined.
+        let key = get("CALIBAN_API_KEY").unwrap();
+        assert!(key.value.is_none());
+        let sel = key.value_from.unwrap().secret_key_ref.unwrap();
+        assert_eq!(sel.name, "anthropic-key");
+        assert_eq!(sel.key, "api-key");
+    }
+
+    #[test]
+    fn provider_env_keyless_has_no_api_key() {
+        use crate::workspace::ResolvedProvider;
+        let rp = ResolvedProvider {
+            name: "workers".into(),
+            kind: "ollama".into(),
+            base_url: Some("http://192.168.1.240:11434".into()),
+            model: None,
+            credentials_ref: None,
+        };
+        let env = provider_env(&rp);
+        assert!(!env.iter().any(|e| e.name == "CALIBAN_API_KEY"));
+        assert!(!env.iter().any(|e| e.name == "CALIBAN_MODEL"));
+        assert_eq!(
+            env.iter().find(|e| e.name == "CALIBAN_PROVIDER").unwrap().value.as_deref(),
+            Some("ollama")
+        );
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p caliban-operator resources::tests::provider_env_projects_kind_url_model_and_secret_ref`
+Expected: FAIL with "cannot find function `provider_env`".
+
+- [ ] **Step 3: Implement `provider_env`**
+
+Add to `src/resources.rs`. Extend the `k8s_openapi` import with `EnvVarSource` and `SecretKeySelector`, then:
+
+```rust
+use crate::workspace::ResolvedProvider;
+
+/// Project a resolved provider to caliband container env. Credentials reach the
+/// pod via `secretKeyRef` (the operator never inlines the value).
+pub(crate) fn provider_env(rp: &ResolvedProvider) -> Vec<EnvVar> {
+    let mut e = vec![env("CALIBAN_PROVIDER", rp.kind.clone())];
+    if let Some(u) = &rp.base_url {
+        e.push(env("CALIBAN_PROVIDER_BASE_URL", u.clone()));
+    }
+    if let Some(m) = &rp.model {
+        e.push(env("CALIBAN_MODEL", m.clone()));
+    }
+    if let Some(c) = &rp.credentials_ref {
+        e.push(EnvVar {
+            name: "CALIBAN_API_KEY".to_string(),
+            value: None,
+            value_from: Some(EnvVarSource {
+                secret_key_ref: Some(SecretKeySelector {
+                    name: c.secret_name.clone(),
+                    key: c.key.clone(),
+                    optional: Some(false),
+                }),
+                ..Default::default()
+            }),
+        });
+    }
+    e
+}
+```
+
+> Note: `SecretKeySelector.name` is a `String` (not `Option`) in k8s-openapi v1_32. If a compile error says it expects `Option<String>`, wrap with `Some(...)` — but v1_32 uses the plain `String`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p caliban-operator resources::tests::provider_env_projects_kind_url_model_and_secret_ref resources::tests::provider_env_keyless_has_no_api_key`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/resources.rs
+git commit -m "feat(resources): provider_env projection with secretKeyRef (#11)"
+```
+
+---
+
+## Task 6: CalibanTask cutover — refs replace inline workspace; reconciler resolves + pins
+
+This is the breaking cutover. It is one atomic commit because removing `spec.workspace` and switching the builders + reconciler to `ResolvedWorkspace` cannot compile half-done. The new pure logic it depends on (Tasks 4–5) is already tested; here we change the schema, rewire the builders/reconciler, fix all fixture fallout, and regenerate the CalibanTask YAML.
+
+**Files:**
+- Modify: `src/crd.rs`, `src/resources.rs`, `src/controller.rs`, `src/config.rs` (test fixtures)
+- Modify: `deploy/crd/calibantask.yaml` (regenerated)
+- Test: updated inline tests across the above
+
+**Interfaces:**
+- Consumes: `ResolvedWorkspace`, `resolve_workspace`, `provider_env` (Tasks 4–5).
+- Produces: `WorkspaceRef { name: String }`; `CalibanTaskSpec { workspace_ref: WorkspaceRef, provider_ref: Option<String>, task: TaskSpec, model, state, isolation, resources, lifecycle, tools: Option<Vec<String>> }`; `CalibanTaskStatus.resolved_workspace: Option<ResolvedWorkspace>`; `plan(t: &CalibanTask, rw: &ResolvedWorkspace, s: &Settings) -> ReconcilePlan`; `build_sandbox(t, rw, s)`.
+
+- [ ] **Step 1: Change the CalibanTask CRD types**
+
+In `src/crd.rs`:
+
+1. Delete the `Workspace` struct (the inline `{ sources, services }` type) entirely.
+2. Replace the `workspace` field on `CalibanTaskSpec` and add the new fields:
+
+```rust
+    /// Reference to the namespace-local `Workspace` this task runs against.
+    pub workspace_ref: WorkspaceRef,
+    /// Which of the workspace's providers to bind; defaults to the workspace's
+    /// `defaultProvider` (or its sole provider).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_ref: Option<String>,
+    /// The task itself.
+    pub task: TaskSpec,
+    // ... existing model / state / isolation / resources / lifecycle unchanged ...
+    /// Per-run tool override (allow-list) for this task's agents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<String>>,
+```
+
+3. Add the `WorkspaceRef` struct near `NamedRef`:
+
+```rust
+/// A by-name reference to a `Workspace` in the same namespace.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceRef {
+    /// Workspace object name.
+    #[schemars(length(min = 1))]
+    pub name: String,
+}
+```
+
+4. Add the pinned field to `CalibanTaskStatus`:
+
+```rust
+    /// Resolved workspace config, pinned at admission (immutable run). Set once;
+    /// later `Workspace` edits don't re-pin a running task.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_workspace: Option<crate::workspace::ResolvedWorkspace>,
+```
+
+5. Update `src/crd.rs`'s own `tests` module: the `SAMPLE`/`minimal_cr_defaults`/`crd_enforces_non_empty_required_fields` fixtures now use `workspaceRef` instead of inline `workspace`. Replace the sample spec bodies, e.g.:
+
+```rust
+    const SAMPLE: &str = r#"
+apiVersion: caliban.caliban-ai.dev/v1alpha1
+kind: CalibanTask
+metadata: { name: refactor-auth, namespace: team-a }
+spec:
+  workspaceRef: { name: team-a-ws }
+  providerRef: planner
+  task: { prompt: "refactor the auth module", agentType: general-purpose }
+  isolation: { runtimeClass: gvisor, worktrees: per-source }
+"#;
+```
+
+Adjust that test's assertions to the new shape (e.g. `task.spec.workspace_ref.name == "team-a-ws"`, `task.spec.provider_ref.as_deref() == Some("planner")`). In `crd_enforces_non_empty_required_fields`, replace the `workspace.sources`/source-field assertions with `spec["workspaceRef"]["properties"]["name"]["minLength"] == 1` (the `sources` constraint now lives on the Workspace CRD test, Task 1).
+
+- [ ] **Step 2: Rewire the resource builders to consume `ResolvedWorkspace`**
+
+In `src/resources.rs`:
+
+1. `clone_script`, `clone_init_container`, `build_sandbox`, `plan` take `rw: &ResolvedWorkspace` and read `rw.sources` instead of `t.spec.workspace.sources`.
+2. `caliband_env(t)` becomes `caliband_env(t, rw)`: keep the existing `state.gonzalo_endpoint` / `model.router_config_ref` env, then extend with `provider_env(&rw.provider)` and the workspace `rw.env` entries:
+
+```rust
+fn caliband_env(t: &CalibanTask, rw: &ResolvedWorkspace) -> Vec<EnvVar> {
+    let mut e = vec![];
+    if let Some(ep) = t.spec.state.as_ref().and_then(|st| st.gonzalo_endpoint.clone()) {
+        e.push(env("GONZALO_ENDPOINT", ep));
+    }
+    if let Some(r) = t.spec.model.as_ref().and_then(|m| m.router_config_ref.clone()) {
+        e.push(env("CALIBAN_ROUTER_CONFIG_REF", r));
+    }
+    e.extend(provider_env(&rw.provider));
+    for kv in &rw.env {
+        e.push(env(&kv.name, kv.value.clone()));
+    }
+    e
+}
+```
+
+3. `build_sandbox` isolation precedence: prefer the task's per-run `t.spec.isolation.runtime_class`, else `rw.isolation.runtime_class`:
+
+```rust
+    runtime_class_name: t
+        .spec
+        .isolation
+        .as_ref()
+        .and_then(|i| i.runtime_class.clone())
+        .or_else(|| rw.isolation.as_ref().and_then(|i| i.runtime_class.clone())),
+```
+
+4. `plan(t, rw, s)` threads `rw` into `build_sandbox`.
+5. Update the `resources::tests` fixtures: the `task()` helper drops the inline `workspace` and sets `workspace_ref`; add a `resolved()` helper returning a `ResolvedWorkspace` (one source, one `ollama` provider), and pass it to `build_sandbox`/`plan`. Every `build_sandbox(&task(), &s)` becomes `build_sandbox(&task(), &resolved(), &s)`.
+
+```rust
+    fn resolved() -> crate::workspace::ResolvedWorkspace {
+        use crate::workspace::{ResolvedProvider, ResolvedWorkspace};
+        ResolvedWorkspace {
+            sources: vec![Source {
+                name: "caliban".into(),
+                repo: "git@x:caliban".into(),
+                r#ref: "main".into(),
+                path: "/work/caliban".into(),
+            }],
+            provider: ResolvedProvider {
+                name: "workers".into(),
+                kind: "ollama".into(),
+                base_url: None,
+                model: None,
+                credentials_ref: None,
+            },
+            env: vec![],
+            isolation: None,
+        }
+    }
+```
+
+- [ ] **Step 3: Rewire the CalibanTask reconciler to resolve + pin**
+
+In `src/controller.rs`, `reconcile`:
+
+1. After computing `ns`/`name`, resolve the workspace before planning. Fetch the referenced `Workspace`; if absent or unresolvable, patch the task status to `Failed` with a message and stop (fail-fast). If the task already has a pinned `status.resolved_workspace`, reuse it (immutable run) rather than re-resolving:
+
+```rust
+    // Pin once: a running task keeps the config it was admitted with.
+    let resolved = match obj.status.as_ref().and_then(|s| s.resolved_workspace.clone()) {
+        Some(rw) => rw,
+        None => {
+            let ws_api: Api<Workspace> = Api::namespaced(ctx.client.clone(), &ns);
+            let ws = ws_api.get_opt(&obj.spec.workspace_ref.name).await?;
+            match ws.and_then(|w| {
+                resolve_workspace(&w.spec, obj.spec.provider_ref.as_deref()).ok()
+            }) {
+                Some(rw) => {
+                    // Persist the pin immediately so it's stable for the run.
+                    let patch = serde_json::json!({ "status": { "resolvedWorkspace": rw } });
+                    let task_api: Api<CalibanTask> = Api::namespaced(ctx.client.clone(), &ns);
+                    task_api
+                        .patch_status(&name, &PatchParams::default(), &Patch::Merge(&patch))
+                        .await?;
+                    rw
+                }
+                None => {
+                    let patch = serde_json::json!({
+                        "status": { "phase": Phase::Failed,
+                            "conditions": [{ "type": "Ready", "status": "False",
+                                "reason": "WorkspaceUnresolved",
+                                "message": format!("workspaceRef '{}' / providerRef unresolved", obj.spec.workspace_ref.name) }] }
+                    });
+                    let task_api: Api<CalibanTask> = Api::namespaced(ctx.client.clone(), &ns);
+                    task_api
+                        .patch_status(&name, &PatchParams::default(), &Patch::Merge(&patch))
+                        .await?;
+                    tracing::warn!(%ns, %name, "workspace unresolved; task Failed");
+                    return Ok(Action::requeue(Duration::from_secs(30)));
+                }
+            }
+        }
+    };
+    let p = plan(&obj, &resolved, s);
+```
+
+2. Add imports: `use crate::workspace::Workspace; use crate::workspace::resolve_workspace;`.
+3. The existing SA/NetworkPolicy/Sandbox apply + `derive_status` block stays, now downstream of `resolved`.
+4. Update `controller::tests` fixtures: `task_without_status()` sets `workspace_ref` instead of inline `workspace`; where it calls `derive_status`, no change (that function is unaffected). Any construction of `CalibanTaskSpec` gains `workspace_ref`, `provider_ref: None`, `tools: None` and drops `workspace`.
+
+- [ ] **Step 4: Fix `config.rs` test fixtures**
+
+`src/config.rs`'s `tests::task()` constructs a `CalibanTaskSpec` with inline `workspace`. Replace that literal with the new shape (`workspace_ref: WorkspaceRef { name: "team-a-ws".into() }`, `provider_ref: None`, `tools: None`, no `workspace`). Import `WorkspaceRef`.
+
+- [ ] **Step 5: Build and fix any remaining fallout**
+
+Run: `cargo build --workspace --all-targets`
+Expected: eventually clean. Fix every construction of `CalibanTaskSpec` the compiler flags (they all need `workspace_ref`/`provider_ref`/`tools` and must drop `workspace`).
+
+- [ ] **Step 6: Regenerate the CalibanTask CRD YAML**
+
+```bash
+cargo run --quiet --bin crdgen calibantask > deploy/crd/calibantask.yaml
+```
+
+- [ ] **Step 7: Run the whole test suite**
+
+Run: `cargo test --workspace`
+Expected: PASS, including `crd::tests::committed_crd_yaml_is_in_sync` (regenerated) and all rewired fixtures.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/crd.rs src/resources.rs src/controller.rs src/config.rs deploy/crd/calibantask.yaml
+git commit -m "feat(crd)!: CalibanTask workspaceRef/providerRef resolve-and-pin; remove inline workspace (#11)"
+```
+
+---
+
+## Task 7: Samples, ADR, docs, and the full gate
+
+**Files:**
+- Create: `deploy/samples/workspace.yaml`, `deploy/samples/calibantask.yaml`
+- Create: `docs/adr/0004-workspace-crd-and-resolve-and-pin.md`
+- Modify: `docs/adr/README.md`, `README.md`
+- Test: a golden test that the sample CRs deserialize against the types
+
+- [ ] **Step 1: Write the sample CRs**
+
+`deploy/samples/workspace.yaml`:
+
+```yaml
+apiVersion: caliban.caliban-ai.dev/v1alpha1
+kind: Workspace
+metadata:
+  name: team-a-ws
+  namespace: team-a
+spec:
+  displayName: Team A
+  sources:
+    - { name: caliban, repo: "git@example:caliban", ref: main, path: /work/caliban }
+  providers:
+    - name: planner
+      kind: anthropic
+      model: claude-opus-4-8
+      credentialsRef: { secretName: anthropic-key, key: api-key }
+    - name: workers
+      kind: ollama
+      baseUrl: "http://192.168.1.240:11434"
+      model: qwen2.5-coder
+  defaultProvider: planner
+```
+
+`deploy/samples/calibantask.yaml`:
+
+```yaml
+apiVersion: caliban.caliban-ai.dev/v1alpha1
+kind: CalibanTask
+metadata:
+  name: refactor-auth
+  namespace: team-a
+spec:
+  workspaceRef: { name: team-a-ws }
+  providerRef: workers
+  task: { prompt: "refactor the auth module", agentType: general-purpose }
+```
+
+- [ ] **Step 2: Write a golden test that the samples deserialize**
+
+Add to `src/workspace.rs` tests:
+
+```rust
+    #[test]
+    fn sample_manifests_deserialize() {
+        let ws: Workspace =
+            serde_norway::from_str(include_str!("../deploy/samples/workspace.yaml")).unwrap();
+        assert_eq!(ws.spec.providers.len(), 2);
+        let ct: crate::crd::CalibanTask =
+            serde_norway::from_str(include_str!("../deploy/samples/calibantask.yaml")).unwrap();
+        assert_eq!(ct.spec.workspace_ref.name, "team-a-ws");
+        assert_eq!(ct.spec.provider_ref.as_deref(), Some("workers"));
+        // The sample CalibanTask references a provider the sample Workspace defines.
+        let r = resolve_workspace(&ws.spec, ct.spec.provider_ref.as_deref()).unwrap();
+        assert_eq!(r.provider.kind, "ollama");
+    }
+```
+
+Run: `cargo test -p caliban-operator workspace::tests::sample_manifests_deserialize`
+Expected: PASS.
+
+- [ ] **Step 3: Write ADR 0004**
+
+Create `docs/adr/0004-workspace-crd-and-resolve-and-pin.md` following the format of `0002-reconcile-calibantask-to-sandbox.md`: **Context** (inline `spec.workspace` has nowhere to persist provider/source config → prospero's k8s config plane returns 405; the epic makes prospero a pure editor of a CRD), **Decision** (first-class `Workspace` CRD with named providers; operator is sole Secret reader; `CalibanTask` gains `workspaceRef`/`providerRef` resolved and pinned at admission; inline `spec.workspace` removed, pre-v1 breaking), **Consequences** (immutable-run preserved via pinning; prospero gets no `secrets` RBAC; multi-namespace tenancy still deferred). Reference the umbrella design doc.
+
+- [ ] **Step 4: Add the ADR index row**
+
+In `docs/adr/README.md`, add a row for `0004` matching the existing table format, status **Accepted**.
+
+- [ ] **Step 5: Update the README dependency/architecture note**
+
+If `README.md` documents the CRDs or the reconcile model, add the `Workspace` CRD and the `workspaceRef` resolve-and-pin flow. Keep it to the existing section's style.
+
+- [ ] **Step 6: Run the full CI gate**
+
+```bash
+cargo fmt --all
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo build --workspace --all-targets
+cargo test --workspace
+```
+
+Expected: all four green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add deploy/samples docs/adr src/workspace.rs README.md
+git commit -m "docs(crd): Workspace/CalibanTask sample CRs + ADR 0004 (#11)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Workspace CRD + generated manifest (T1), validation-and-status reconciler / operator-sole-Secret-reader (T2–T3), `workspaceRef`/`providerRef` + resolve-and-pin + `status.resolvedWorkspace` (T4, T6), inline-workspace removal / breaking (T6), RBAC — **cross-repo (helm-charts#30), out of scope here; called out in ADR 0004**, sample CRs for the cross-repo contract test (T7). Golden CRD serialization (T1, T6), reconciler pure-fn unit tests (T2, T3, T4, T5), resolve+pin (T4, T6). Missing from *this* plan by design: prospero mirror tests (prospero#141), envtest (repo has no harness; substituted by pure-fn + golden per the design's own CI caveat).
+- **Type consistency:** `ResolvedWorkspace`/`ResolvedProvider`/`CredentialsRef`/`EnvEntry` names are used identically in `workspace.rs` (defined), `resources.rs` (`provider_env`), `crd.rs` (`CalibanTaskStatus.resolved_workspace`), and `controller.rs` (pin). `resolve_workspace(spec, Option<&str>) -> Result<ResolvedWorkspace, String>` and `validate_workspace(spec, impl Fn(&str,&str)->bool) -> WorkspaceValidation` signatures are stable across their call sites.
+- **Open verification risk:** `SecretKeySelector.name` type (plain `String` in k8s-openapi v1_32) — noted inline in T5; confirm at build. The k8s paths (secret read, status patch) are compile- and unit-verified only; a live-cluster smoke is the real gate (design reality-caveat).

--- a/src/bin/caliban-operator.rs
+++ b/src/bin/caliban-operator.rs
@@ -8,5 +8,9 @@ async fn main() -> anyhow::Result<()> {
     tracing::info!("caliban-operator starting");
     let client = kube::Client::try_default().await?;
     tracing::info!("connected to the Kubernetes API");
-    caliban_operator::controller::run(client).await
+    tokio::try_join!(
+        caliban_operator::controller::run(client.clone()),
+        caliban_operator::workspace_controller::run(client),
+    )?;
+    Ok(())
 }

--- a/src/bin/crdgen.rs
+++ b/src/bin/crdgen.rs
@@ -1,9 +1,16 @@
-//! Emit the CalibanTask CRD YAML: `cargo run --bin crdgen > deploy/crd/calibantask.yaml`.
+//! Emit a CRD's YAML: `cargo run --bin crdgen <calibantask|workspace> > deploy/crd/<kind>.yaml`.
 
 use kube::CustomResourceExt;
 
 fn main() -> anyhow::Result<()> {
-    let crd = caliban_operator::crd::CalibanTask::crd();
-    print!("{}", serde_norway::to_string(&crd)?);
+    let kind = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "calibantask".into());
+    let yaml = match kind.as_str() {
+        "calibantask" => serde_norway::to_string(&caliban_operator::crd::CalibanTask::crd())?,
+        "workspace" => serde_norway::to_string(&caliban_operator::workspace::Workspace::crd())?,
+        other => anyhow::bail!("unknown CRD kind {other:?}; expected calibantask|workspace"),
+    };
+    print!("{yaml}");
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,21 +93,16 @@ pub fn owner_ref(t: &CalibanTask) -> OwnerReference {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::crd::{CalibanTask, CalibanTaskSpec, Source, TaskSpec, Workspace};
+    use crate::crd::{CalibanTask, CalibanTaskSpec, TaskSpec, WorkspaceRef};
 
     fn task() -> CalibanTask {
         let mut t = CalibanTask::new(
             "refactor-auth",
             CalibanTaskSpec {
-                workspace: Workspace {
-                    sources: vec![Source {
-                        name: "caliban".into(),
-                        repo: "git@x:caliban".into(),
-                        r#ref: "main".into(),
-                        path: "/work/caliban".into(),
-                    }],
-                    services: vec![],
+                workspace_ref: WorkspaceRef {
+                    name: "team-a-ws".into(),
                 },
+                provider_ref: None,
                 task: TaskSpec {
                     prompt: "hi".into(),
                     agent_type: None,
@@ -117,6 +112,7 @@ mod tests {
                 isolation: None,
                 resources: None,
                 lifecycle: None,
+                tools: None,
             },
         );
         t.metadata.namespace = Some("team-a".into());

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -368,5 +368,12 @@ mod tests {
         // Merge-patch needs explicit null (not absent) to delete the stale values.
         assert!(v.get("calibandEndpoint").is_some_and(|x| x.is_null()));
         assert!(v.get("sandboxRef").is_some_and(|x| x.is_null()));
+        // Regression guard: a Running->Pending transition must serialize
+        // `conditions` as an explicit empty array, not omit the key. Under
+        // JSON Merge Patch an omitted key is left unchanged server-side, so
+        // if `conditions` were skipped here the stale `Ready=True` condition
+        // would never be cleared and every subsequent reconcile would keep
+        // re-patching (endless churn).
+        assert_eq!(v.get("conditions"), Some(&serde_json::json!([])));
     }
 }

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -16,7 +16,7 @@ use kube::runtime::Controller;
 use kube::{Api, Client, Resource, ResourceExt};
 
 use crate::config::{sandbox_name, Settings};
-use crate::crd::{CalibanTask, CalibanTaskStatus, NamedRef, Phase};
+use crate::crd::{CalibanTask, CalibanTaskStatus, Condition, NamedRef, Phase};
 use crate::resources::plan;
 use crate::sandbox::Sandbox;
 use crate::workspace::resolve_workspace;
@@ -63,6 +63,21 @@ pub(crate) fn derive_status(
     next.sandbox_ref = sandbox.map(|_| NamedRef {
         name: sandbox_name(t),
     });
+    // `derive_status` is the single owner of the `Ready` condition and is only
+    // ever reached after the workspace has resolved (the fail-fast branch in
+    // `reconcile` returns early, before this is called). So any
+    // `WorkspaceUnresolved` condition carried in the stale in-memory
+    // `t.status` (cloned above) is by definition stale and must not survive:
+    // derive it fresh from the phase instead of leaving whatever was there.
+    next.conditions = match phase {
+        Phase::Running => vec![Condition {
+            type_: "Ready".into(),
+            status: "True".into(),
+            reason: Some("Running".into()),
+            message: None,
+        }],
+        _ => Vec::new(),
+    };
     match &t.status {
         Some(cur) if status_eq(cur, &next) => None,
         _ => Some(next),
@@ -73,6 +88,7 @@ fn status_eq(a: &CalibanTaskStatus, b: &CalibanTaskStatus) -> bool {
     a.phase == b.phase
         && a.caliband_endpoint == b.caliband_endpoint
         && a.sandbox_ref.as_ref().map(|r| &r.name) == b.sandbox_ref.as_ref().map(|r| &r.name)
+        && a.conditions == b.conditions
 }
 
 /// Server-side apply `obj` under `name`, force-owned by the operator's field
@@ -103,17 +119,28 @@ async fn reconcile(obj: Arc<CalibanTask>, ctx: Arc<Context>) -> Result<Action, E
         None => {
             let ws_api: Api<Workspace> = Api::namespaced(ctx.client.clone(), &ns);
             let ws = ws_api.get_opt(&obj.spec.workspace_ref.name).await?;
-            match ws.and_then(|w| resolve_workspace(&w.spec, obj.spec.provider_ref.as_deref()).ok())
-            {
-                Some(rw) => {
+            // Distinguish "no such Workspace" from a `resolve_workspace` failure
+            // (dangling providerRef, ambiguous default, ...) so the specific
+            // reason makes it into the condition's human-readable `message`
+            // instead of collapsing every unresolved case into one generic
+            // string. `reason` stays the fixed `WorkspaceUnresolved`.
+            let resolution: Result<crate::workspace::ResolvedWorkspace, String> = match ws {
+                Some(w) => resolve_workspace(&w.spec, obj.spec.provider_ref.as_deref()),
+                None => Err(format!(
+                    "Workspace not found: '{}'",
+                    obj.spec.workspace_ref.name
+                )),
+            };
+            match resolution {
+                Ok(rw) => {
                     // Persist the pin immediately so it's stable for the run.
-                    // Also clear any stale `WorkspaceUnresolved` condition left
-                    // by a prior fail-fast reconcile: `derive_status` never
-                    // touches `conditions`, so without this the recovered task
-                    // would carry a permanent Ready=False alongside a healthy
-                    // phase.
+                    // Any stale `WorkspaceUnresolved` condition left by a prior
+                    // fail-fast reconcile is cleared once `derive_status` runs
+                    // later this same reconcile (it owns `conditions` and
+                    // derives them fresh from the phase), so it need not be
+                    // touched here.
                     let patch = serde_json::json!({
-                        "status": { "resolvedWorkspace": rw, "conditions": [] }
+                        "status": { "resolvedWorkspace": rw }
                     });
                     let task_api: Api<CalibanTask> = Api::namespaced(ctx.client.clone(), &ns);
                     task_api
@@ -121,12 +148,12 @@ async fn reconcile(obj: Arc<CalibanTask>, ctx: Arc<Context>) -> Result<Action, E
                         .await?;
                     rw
                 }
-                None => {
+                Err(reason) => {
                     let patch = serde_json::json!({
                         "status": { "phase": Phase::Failed,
                             "conditions": [{ "type": "Ready", "status": "False",
                                 "reason": "WorkspaceUnresolved",
-                                "message": format!("workspaceRef '{}' / providerRef unresolved", obj.spec.workspace_ref.name) }] }
+                                "message": reason }] }
                     });
                     let task_api: Api<CalibanTask> = Api::namespaced(ctx.client.clone(), &ns);
                     task_api
@@ -245,6 +272,7 @@ mod tests {
         let d = super::derive_status(&t, None, &Settings::default()).unwrap();
         assert_eq!(d.phase, Phase::Pending);
         assert!(d.caliband_endpoint.is_none());
+        assert!(d.conditions.is_empty());
     }
 
     #[test]
@@ -254,6 +282,7 @@ mod tests {
         let d = super::derive_status(&t, Some(&sb), &Settings::default()).unwrap();
         assert_eq!(d.phase, Phase::Provisioning);
         assert_eq!(d.sandbox_ref.unwrap().name, "refactor-auth-sbx");
+        assert!(d.conditions.is_empty());
     }
 
     #[test]
@@ -266,6 +295,10 @@ mod tests {
             d.caliband_endpoint.as_deref(),
             Some("refactor-auth-sbx.team-a.svc:8443")
         );
+        // Running phase must carry a derived Ready=True condition.
+        assert_eq!(d.conditions.len(), 1);
+        assert_eq!(d.conditions[0].type_, "Ready");
+        assert_eq!(d.conditions[0].status, "True");
     }
 
     #[test]
@@ -275,6 +308,39 @@ mod tests {
         // First derivation, then apply it as the observed status.
         t.status = super::derive_status(&t, Some(&sb), &Settings::default());
         assert!(super::derive_status(&t, Some(&sb), &Settings::default()).is_none());
+    }
+
+    #[test]
+    fn stale_workspace_unresolved_condition_does_not_survive_into_running() {
+        // Regression guard: a task carrying a stale `Ready=False /
+        // WorkspaceUnresolved` condition (left over from an earlier fail-fast
+        // reconcile) must NOT keep that condition once the workspace resolves
+        // and the Sandbox comes up Running. `derive_status` owns
+        // `conditions` and must derive them fresh from the phase it computes,
+        // not carry forward whatever was in the stale in-memory status.
+        let mut t = task_without_status();
+        t.status = Some(CalibanTaskStatus {
+            phase: Phase::Failed,
+            conditions: vec![Condition {
+                type_: "Ready".into(),
+                status: "False".into(),
+                reason: Some("WorkspaceUnresolved".into()),
+                message: Some("workspaceRef 'team-a-ws' / providerRef unresolved".into()),
+            }],
+            ..Default::default()
+        });
+        let sb = sandbox_with_fqdn(Some("refactor-auth-sbx.team-a.svc"));
+        let d = super::derive_status(&t, Some(&sb), &Settings::default()).unwrap();
+        assert_eq!(d.phase, Phase::Running);
+        assert!(
+            !d.conditions
+                .iter()
+                .any(|c| c.reason.as_deref() == Some("WorkspaceUnresolved")),
+            "stale WorkspaceUnresolved condition survived into Running: {:?}",
+            d.conditions
+        );
+        assert_eq!(d.conditions.len(), 1);
+        assert_eq!(d.conditions[0].status, "True");
     }
 
     #[test]

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -19,6 +19,8 @@ use crate::config::{sandbox_name, Settings};
 use crate::crd::{CalibanTask, CalibanTaskStatus, NamedRef, Phase};
 use crate::resources::plan;
 use crate::sandbox::Sandbox;
+use crate::workspace::resolve_workspace;
+use crate::workspace::Workspace;
 
 /// Controller error.
 #[derive(thiserror::Error, Debug)]
@@ -89,7 +91,54 @@ async fn reconcile(obj: Arc<CalibanTask>, ctx: Arc<Context>) -> Result<Action, E
     let ns = obj.namespace().unwrap_or_default();
     let name = obj.name_any();
     let s = &ctx.settings;
-    let p = plan(&obj, s);
+
+    // Pin once: a running task keeps the config it was admitted with. Later
+    // edits to the referenced `Workspace` don't re-pin (or disturb) a running task.
+    let resolved = match obj
+        .status
+        .as_ref()
+        .and_then(|st| st.resolved_workspace.clone())
+    {
+        Some(rw) => rw,
+        None => {
+            let ws_api: Api<Workspace> = Api::namespaced(ctx.client.clone(), &ns);
+            let ws = ws_api.get_opt(&obj.spec.workspace_ref.name).await?;
+            match ws.and_then(|w| resolve_workspace(&w.spec, obj.spec.provider_ref.as_deref()).ok())
+            {
+                Some(rw) => {
+                    // Persist the pin immediately so it's stable for the run.
+                    // Also clear any stale `WorkspaceUnresolved` condition left
+                    // by a prior fail-fast reconcile: `derive_status` never
+                    // touches `conditions`, so without this the recovered task
+                    // would carry a permanent Ready=False alongside a healthy
+                    // phase.
+                    let patch = serde_json::json!({
+                        "status": { "resolvedWorkspace": rw, "conditions": [] }
+                    });
+                    let task_api: Api<CalibanTask> = Api::namespaced(ctx.client.clone(), &ns);
+                    task_api
+                        .patch_status(&name, &PatchParams::default(), &Patch::Merge(&patch))
+                        .await?;
+                    rw
+                }
+                None => {
+                    let patch = serde_json::json!({
+                        "status": { "phase": Phase::Failed,
+                            "conditions": [{ "type": "Ready", "status": "False",
+                                "reason": "WorkspaceUnresolved",
+                                "message": format!("workspaceRef '{}' / providerRef unresolved", obj.spec.workspace_ref.name) }] }
+                    });
+                    let task_api: Api<CalibanTask> = Api::namespaced(ctx.client.clone(), &ns);
+                    task_api
+                        .patch_status(&name, &PatchParams::default(), &Patch::Merge(&patch))
+                        .await?;
+                    tracing::warn!(%ns, %name, "workspace unresolved; task Failed");
+                    return Ok(Action::requeue(Duration::from_secs(30)));
+                }
+            }
+        }
+    };
+    let p = plan(&obj, &resolved, s);
 
     // Apply children (idempotent SSA; owner refs cascade-delete).
     let sa_api: Api<ServiceAccount> = Api::namespaced(ctx.client.clone(), &ns);
@@ -143,7 +192,7 @@ pub async fn run(client: Client) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::crd::{CalibanTaskSpec, Source, TaskSpec, Workspace};
+    use crate::crd::{CalibanTaskSpec, TaskSpec, WorkspaceRef};
     use crate::sandbox::{SandboxSpec, SandboxStatus};
     use k8s_openapi::api::core::v1::PodTemplateSpec;
 
@@ -151,15 +200,10 @@ mod tests {
         let mut t = CalibanTask::new(
             "refactor-auth",
             CalibanTaskSpec {
-                workspace: Workspace {
-                    sources: vec![Source {
-                        name: "caliban".into(),
-                        repo: "git@x:caliban".into(),
-                        r#ref: "main".into(),
-                        path: "/work/caliban".into(),
-                    }],
-                    services: vec![],
+                workspace_ref: WorkspaceRef {
+                    name: "team-a-ws".into(),
                 },
+                provider_ref: None,
                 task: TaskSpec {
                     prompt: "hi".into(),
                     agent_type: None,
@@ -169,6 +213,7 @@ mod tests {
                 isolation: None,
                 resources: None,
                 lifecycle: None,
+                tools: None,
             },
         );
         t.metadata.namespace = Some("team-a".into());

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -173,7 +173,15 @@ pub struct CalibanTaskStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace: Option<WorkspaceStatus>,
     /// Standard Kubernetes conditions.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    // No `skip_serializing_if` here either (see `caliband_endpoint` above):
+    // `derive_status` sets this to `[]` to clear a stale `Ready` condition
+    // when the phase leaves `Running`. Under JSON Merge Patch, an *omitted*
+    // key is left unchanged server-side, so an empty `Vec` must still
+    // serialize as `"conditions": []` — skipping it here would leave the
+    // stale condition on the server forever (and cause endless reconcile
+    // churn, since the next read would keep disagreeing with what
+    // `derive_status` recomputes).
+    #[serde(default)]
     pub conditions: Vec<Condition>,
     /// Resolved workspace config, pinned at admission (immutable run). Set once;
     /// later `Workspace` edits don't re-pin a running task.

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -19,8 +19,12 @@ use serde::{Deserialize, Serialize};
 )]
 #[serde(rename_all = "camelCase")]
 pub struct CalibanTaskSpec {
-    /// The workspace (1..N source checkouts) the task runs over.
-    pub workspace: Workspace,
+    /// Reference to the namespace-local `Workspace` this task runs against.
+    pub workspace_ref: WorkspaceRef,
+    /// Which of the workspace's providers to bind; defaults to the workspace's
+    /// `defaultProvider` (or its sole provider).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_ref: Option<String>,
     /// The task itself.
     pub task: TaskSpec,
     /// Model-router configuration.
@@ -38,18 +42,18 @@ pub struct CalibanTaskSpec {
     /// Idle/drain lifecycle policy.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lifecycle: Option<LifecycleSpec>,
+    /// Per-run tool override (allow-list) for this task's agents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<String>>,
 }
 
-/// A workspace: the provisioned source set + optional in-pod aux services.
+/// A by-name reference to a `Workspace` in the same namespace.
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct Workspace {
-    /// The guaranteed source checkouts (runtime-extensible).
+pub struct WorkspaceRef {
+    /// Workspace object name.
     #[schemars(length(min = 1))]
-    pub sources: Vec<Source>,
-    /// Optional in-pod aux services (e.g. gonzalod, prosperod) for e2e.
-    #[serde(default)]
-    pub services: Vec<String>,
+    pub name: String,
 }
 
 /// A single source checkout in the workspace.
@@ -171,6 +175,10 @@ pub struct CalibanTaskStatus {
     /// Standard Kubernetes conditions.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<Condition>,
+    /// Resolved workspace config, pinned at admission (immutable run). Set once;
+    /// later `Workspace` edits don't re-pin a running task.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_workspace: Option<crate::workspace::ResolvedWorkspace>,
 }
 
 /// A by-name reference to another object in the same namespace.
@@ -234,16 +242,11 @@ mod tests {
     const SAMPLE: &str = r#"
 apiVersion: caliban.caliban-ai.dev/v1alpha1
 kind: CalibanTask
-metadata:
-  name: refactor-auth
-  namespace: team-a
+metadata: { name: refactor-auth, namespace: team-a }
 spec:
-  workspace:
-    sources:
-      - { name: caliban,  repo: "git@example:caliban",  ref: main,       path: /work/caliban }
-      - { name: prospero, repo: "git@example:prospero", ref: feat-xport, path: /work/prospero }
-    services: [ gonzalod, prosperod ]
-  task:      { prompt: "refactor the auth module", agentType: general-purpose }
+  workspaceRef: { name: team-a-ws }
+  providerRef: planner
+  task: { prompt: "refactor the auth module", agentType: general-purpose }
   model:     { routerConfigRef: caliban-router }
   state:     { gonzaloEndpoint: gonzalod.storage.svc, mode: remote }
   isolation: { runtimeClass: gvisor, worktrees: per-source }
@@ -254,10 +257,8 @@ spec:
     #[test]
     fn sample_cr_round_trips() {
         let task: CalibanTask = serde_norway::from_str(SAMPLE).expect("deserialize sample");
-        assert_eq!(task.spec.workspace.sources.len(), 2);
-        assert_eq!(task.spec.workspace.sources[0].name, "caliban");
-        assert_eq!(task.spec.workspace.sources[1].r#ref, "feat-xport");
-        assert_eq!(task.spec.workspace.services, vec!["gonzalod", "prosperod"]);
+        assert_eq!(task.spec.workspace_ref.name, "team-a-ws");
+        assert_eq!(task.spec.provider_ref.as_deref(), Some("planner"));
         assert_eq!(task.spec.task.prompt, "refactor the auth module");
         assert_eq!(
             task.spec.task.agent_type.as_deref(),
@@ -281,6 +282,10 @@ spec:
         let json = serde_json::to_value(&task.spec).unwrap();
         assert!(
             json["task"]["agentType"].is_string(),
+            "camelCase key expected"
+        );
+        assert!(
+            json["workspaceRef"]["name"].is_string(),
             "camelCase key expected"
         );
     }
@@ -313,26 +318,18 @@ spec:
 
     #[test]
     fn crd_enforces_non_empty_required_fields() {
-        // Semantically-invalid CRs (`sources: []`, `prompt: ""`) must be rejected
-        // by the API server, not admitted and set to Pending. The generated CRD
-        // schema carries the constraints (schemars `length(min = 1)`).
+        // Semantically-invalid CRs (`workspaceRef.name: ""`, `prompt: ""`) must be
+        // rejected by the API server, not admitted and set to Pending. The
+        // generated CRD schema carries the constraints (schemars `length(min = 1)`).
+        // (The `sources` constraint now lives on the Workspace CRD; see workspace.rs.)
         let crd = CalibanTask::crd();
         let schema = serde_json::to_value(&crd.spec.versions[0].schema).unwrap();
         let spec = &schema["openAPIV3Schema"]["properties"]["spec"]["properties"];
 
-        // sources: at least one checkout.
         assert_eq!(
-            spec["workspace"]["properties"]["sources"]["minItems"], 1,
-            "workspace.sources must require minItems: 1"
+            spec["workspaceRef"]["properties"]["name"]["minLength"], 1,
+            "workspaceRef.name must require minLength: 1"
         );
-        // Required strings: no empty values.
-        let source_props = &spec["workspace"]["properties"]["sources"]["items"]["properties"];
-        for field in ["name", "repo", "path"] {
-            assert_eq!(
-                source_props[field]["minLength"], 1,
-                "source.{field} must require minLength: 1"
-            );
-        }
         assert_eq!(
             spec["task"]["properties"]["prompt"]["minLength"], 1,
             "task.prompt must require minLength: 1"
@@ -347,13 +344,14 @@ apiVersion: caliban.caliban-ai.dev/v1alpha1
 kind: CalibanTask
 metadata: { name: m, namespace: n }
 spec:
-  workspace: { sources: [ { name: only, repo: "git@x:only", path: /work/only } ] }
+  workspaceRef: { name: only-ws }
   task: { prompt: hi }
 "#;
         let task: CalibanTask = serde_norway::from_str(yaml).unwrap();
-        assert_eq!(task.spec.workspace.sources[0].r#ref, "main"); // default ref
-        assert!(task.spec.workspace.services.is_empty());
+        assert_eq!(task.spec.workspace_ref.name, "only-ws");
+        assert!(task.spec.provider_ref.is_none());
         assert!(task.spec.model.is_none());
         assert!(task.spec.task.agent_type.is_none());
+        assert!(task.spec.tools.is_none());
     }
 }

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -199,7 +199,7 @@ pub struct WorkspaceStatus {
 }
 
 /// A minimal Kubernetes-style condition.
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Condition {
     /// Condition type (e.g. `Ready`).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,5 +7,8 @@ pub mod controller;
 pub mod crd;
 pub mod resources;
 pub mod sandbox;
+pub mod workspace;
+pub mod workspace_controller;
 
 pub use crd::{CalibanTask, CalibanTaskSpec, CalibanTaskStatus, Phase};
+pub use workspace::{Workspace, WorkspaceSpec, WorkspaceStatus};

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -20,7 +20,7 @@ use kube::ResourceExt;
 use crate::config::{common_labels, netpol_name, owner_ref, sa_name, sandbox_name, Settings};
 use crate::crd::CalibanTask;
 use crate::sandbox::{Sandbox, SandboxSpec, VolumeClaimTemplate};
-use crate::workspace::ResolvedProvider;
+use crate::workspace::{ResolvedProvider, ResolvedWorkspace};
 
 fn child_meta(t: &CalibanTask, name: String, labels: BTreeMap<String, String>) -> ObjectMeta {
     ObjectMeta {
@@ -90,7 +90,7 @@ fn env(name: &str, value: String) -> EnvVar {
     }
 }
 
-fn caliband_env(t: &CalibanTask) -> Vec<EnvVar> {
+fn caliband_env(t: &CalibanTask, rw: &ResolvedWorkspace) -> Vec<EnvVar> {
     let mut e = vec![];
     if let Some(ep) = t
         .spec
@@ -108,12 +108,15 @@ fn caliband_env(t: &CalibanTask) -> Vec<EnvVar> {
     {
         e.push(env("CALIBAN_ROUTER_CONFIG_REF", r));
     }
+    e.extend(provider_env(&rw.provider));
+    for kv in &rw.env {
+        e.push(env(&kv.name, kv.value.clone()));
+    }
     e
 }
 
 /// Project a resolved provider to caliband container env. Credentials reach the
 /// pod via `secretKeyRef` (the operator never inlines the value).
-#[allow(dead_code)]
 pub(crate) fn provider_env(rp: &ResolvedProvider) -> Vec<EnvVar> {
     let mut e = vec![env("CALIBAN_PROVIDER", rp.kind.clone())];
     if let Some(u) = &rp.base_url {
@@ -147,9 +150,9 @@ fn sh_squote(v: &str) -> String {
 /// Build the idempotent clone script for the init container: for each workspace
 /// source, clone `repo` at `ref` into `path` unless it's already a git checkout
 /// (so pause/resume and pod restarts over the persistent PVC don't refetch).
-fn clone_script(t: &CalibanTask) -> String {
+fn clone_script(rw: &ResolvedWorkspace) -> String {
     let mut s = String::from("set -eu\n");
-    for src in &t.spec.workspace.sources {
+    for src in &rw.sources {
         s.push_str(&format!(
             "if [ ! -d {git} ]; then git clone --depth 1 --branch {r} {repo} {path}; fi\n",
             git = sh_squote(&format!("{}/.git", src.path)),
@@ -161,10 +164,10 @@ fn clone_script(t: &CalibanTask) -> String {
     s
 }
 
-/// The git-clone init container that populates the workspace volume from
-/// `spec.workspace.sources[]`, if any are configured.
-fn clone_init_container(t: &CalibanTask, s: &Settings) -> Option<Container> {
-    if t.spec.workspace.sources.is_empty() {
+/// The git-clone init container that populates the workspace volume from the
+/// resolved workspace's `sources[]`, if any are configured.
+fn clone_init_container(rw: &ResolvedWorkspace, s: &Settings) -> Option<Container> {
+    if rw.sources.is_empty() {
         return None;
     }
     Some(Container {
@@ -173,7 +176,7 @@ fn clone_init_container(t: &CalibanTask, s: &Settings) -> Option<Container> {
         command: Some(vec![
             "/bin/sh".to_string(),
             "-c".to_string(),
-            clone_script(t),
+            clone_script(rw),
         ]),
         volume_mounts: Some(vec![VolumeMount {
             name: WORKSPACE_VOLUME.to_string(),
@@ -205,8 +208,9 @@ fn workspace_pvc(s: &Settings) -> VolumeClaimTemplate {
     }
 }
 
-/// Map a `CalibanTask` to its backing agent-sandbox `Sandbox`.
-pub fn build_sandbox(t: &CalibanTask, s: &Settings) -> Sandbox {
+/// Map a `CalibanTask` + its resolved workspace to the backing agent-sandbox
+/// `Sandbox`.
+pub fn build_sandbox(t: &CalibanTask, rw: &ResolvedWorkspace, s: &Settings) -> Sandbox {
     let labels = common_labels(t);
     let container = Container {
         name: "caliband".to_string(),
@@ -222,7 +226,7 @@ pub fn build_sandbox(t: &CalibanTask, s: &Settings) -> Sandbox {
             "--listen".to_string(),
             format!("0.0.0.0:{}", s.caliband_port),
         ]),
-        env: Some(caliband_env(t)),
+        env: Some(caliband_env(t, rw)),
         volume_mounts: Some(vec![VolumeMount {
             name: WORKSPACE_VOLUME.to_string(),
             mount_path: s.workspace_root.clone(),
@@ -232,12 +236,14 @@ pub fn build_sandbox(t: &CalibanTask, s: &Settings) -> Sandbox {
     };
     let pod_spec = PodSpec {
         containers: vec![container],
-        init_containers: clone_init_container(t, s).map(|c| vec![c]),
+        init_containers: clone_init_container(rw, s).map(|c| vec![c]),
+        // The task's per-run override takes precedence over the workspace default.
         runtime_class_name: t
             .spec
             .isolation
             .as_ref()
-            .and_then(|i| i.runtime_class.clone()),
+            .and_then(|i| i.runtime_class.clone())
+            .or_else(|| rw.isolation.as_ref().and_then(|i| i.runtime_class.clone())),
         service_account_name: Some(sa_name(t)),
         automount_service_account_token: Some(false),
         ..Default::default()
@@ -274,32 +280,27 @@ pub struct ReconcilePlan {
 }
 
 /// Assemble every child object for a task (pure).
-pub fn plan(t: &CalibanTask, s: &Settings) -> ReconcilePlan {
+pub fn plan(t: &CalibanTask, rw: &ResolvedWorkspace, s: &Settings) -> ReconcilePlan {
     ReconcilePlan {
         service_account: build_service_account(t),
         network_policy: build_network_policy(t, s),
-        sandbox: build_sandbox(t, s),
+        sandbox: build_sandbox(t, rw, s),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::crd::{CalibanTaskSpec, Source, TaskSpec, Workspace};
+    use crate::crd::{CalibanTaskSpec, Source, TaskSpec, WorkspaceRef};
 
     fn task() -> CalibanTask {
         let mut t = CalibanTask::new(
             "refactor-auth",
             CalibanTaskSpec {
-                workspace: Workspace {
-                    sources: vec![Source {
-                        name: "caliban".into(),
-                        repo: "git@x:caliban".into(),
-                        r#ref: "main".into(),
-                        path: "/work/caliban".into(),
-                    }],
-                    services: vec![],
+                workspace_ref: WorkspaceRef {
+                    name: "team-a-ws".into(),
                 },
+                provider_ref: None,
                 task: TaskSpec {
                     prompt: "hi".into(),
                     agent_type: None,
@@ -309,11 +310,33 @@ mod tests {
                 isolation: None,
                 resources: None,
                 lifecycle: None,
+                tools: None,
             },
         );
         t.metadata.namespace = Some("team-a".into());
         t.metadata.uid = Some("uid-123".into());
         t
+    }
+
+    fn resolved() -> crate::workspace::ResolvedWorkspace {
+        use crate::workspace::{ResolvedProvider, ResolvedWorkspace};
+        ResolvedWorkspace {
+            sources: vec![Source {
+                name: "caliban".into(),
+                repo: "git@x:caliban".into(),
+                r#ref: "main".into(),
+                path: "/work/caliban".into(),
+            }],
+            provider: ResolvedProvider {
+                name: "workers".into(),
+                kind: "ollama".into(),
+                base_url: None,
+                model: None,
+                credentials_ref: None,
+            },
+            env: vec![],
+            isolation: None,
+        }
     }
 
     #[test]
@@ -362,7 +385,7 @@ mod tests {
     #[test]
     fn sandbox_has_caliband_container_pvc_and_service() {
         let s = Settings::default();
-        let sb = build_sandbox(&task(), &s);
+        let sb = build_sandbox(&task(), &resolved(), &s);
         assert_eq!(sb.metadata.name.as_deref(), Some("refactor-auth-sbx"));
         assert_eq!(sb.metadata.namespace.as_deref(), Some("team-a"));
         assert_eq!(sb.spec.service, Some(true));
@@ -414,7 +437,7 @@ mod tests {
     #[test]
     fn sandbox_has_git_clone_init_container_for_workspace_sources() {
         let s = Settings::default();
-        let sb = build_sandbox(&task(), &s);
+        let sb = build_sandbox(&task(), &resolved(), &s);
         let pod = sb.spec.pod_template.spec.unwrap();
         let inits = pod.init_containers.expect("init containers present");
         assert_eq!(inits.len(), 1);
@@ -440,9 +463,10 @@ mod tests {
 
     #[test]
     fn clone_script_shell_escapes_source_values() {
-        let mut t = task();
-        t.spec.workspace.sources[0].repo = "https://x/a'b".into();
-        let sb = build_sandbox(&t, &Settings::default());
+        let t = task();
+        let mut rw = resolved();
+        rw.sources[0].repo = "https://x/a'b".into();
+        let sb = build_sandbox(&t, &rw, &Settings::default());
         let pod = sb.spec.pod_template.spec.unwrap();
         let init = &pod.init_containers.unwrap()[0];
         let script = &init.command.as_ref().unwrap()[2];
@@ -452,9 +476,10 @@ mod tests {
 
     #[test]
     fn sandbox_omits_init_containers_when_no_workspace_sources() {
-        let mut t = task();
-        t.spec.workspace.sources = vec![];
-        let sb = build_sandbox(&t, &Settings::default());
+        let t = task();
+        let mut rw = resolved();
+        rw.sources = vec![];
+        let sb = build_sandbox(&t, &rw, &Settings::default());
         let pod = sb.spec.pod_template.spec.unwrap();
         assert!(pod.init_containers.is_none());
     }
@@ -467,7 +492,53 @@ mod tests {
             runtime_class: Some("gvisor".into()),
             worktrees: None,
         });
-        let sb = build_sandbox(&t, &Settings::default());
+        let sb = build_sandbox(&t, &resolved(), &Settings::default());
+        assert_eq!(
+            sb.spec
+                .pod_template
+                .spec
+                .unwrap()
+                .runtime_class_name
+                .as_deref(),
+            Some("gvisor")
+        );
+    }
+
+    #[test]
+    fn sandbox_runtime_class_falls_back_to_workspace_isolation() {
+        use crate::crd::IsolationSpec;
+        let t = task();
+        let mut rw = resolved();
+        rw.isolation = Some(IsolationSpec {
+            runtime_class: Some("kata".into()),
+            worktrees: None,
+        });
+        let sb = build_sandbox(&t, &rw, &Settings::default());
+        assert_eq!(
+            sb.spec
+                .pod_template
+                .spec
+                .unwrap()
+                .runtime_class_name
+                .as_deref(),
+            Some("kata")
+        );
+    }
+
+    #[test]
+    fn sandbox_runtime_class_task_override_wins_over_workspace() {
+        use crate::crd::IsolationSpec;
+        let mut t = task();
+        t.spec.isolation = Some(IsolationSpec {
+            runtime_class: Some("gvisor".into()),
+            worktrees: None,
+        });
+        let mut rw = resolved();
+        rw.isolation = Some(IsolationSpec {
+            runtime_class: Some("kata".into()),
+            worktrees: None,
+        });
+        let sb = build_sandbox(&t, &rw, &Settings::default());
         assert_eq!(
             sb.spec
                 .pod_template
@@ -486,7 +557,7 @@ mod tests {
         t.spec.model = Some(ModelSpec {
             router_config_ref: Some("caliban-router".into()),
         });
-        let sb = build_sandbox(&t, &Settings::default());
+        let sb = build_sandbox(&t, &resolved(), &Settings::default());
         let pod = sb.spec.pod_template.spec.unwrap();
         let env = pod.containers[0].env.as_ref().unwrap();
         assert!(env.iter().any(|e| e.name == "CALIBAN_ROUTER_CONFIG_REF"
@@ -494,8 +565,28 @@ mod tests {
     }
 
     #[test]
+    fn sandbox_projects_resolved_provider_and_workspace_env() {
+        use crate::workspace::EnvEntry;
+        let t = task();
+        let mut rw = resolved();
+        rw.env = vec![EnvEntry {
+            name: "FOO".into(),
+            value: "bar".into(),
+        }];
+        let sb = build_sandbox(&t, &rw, &Settings::default());
+        let pod = sb.spec.pod_template.spec.unwrap();
+        let env = pod.containers[0].env.as_ref().unwrap();
+        assert!(env
+            .iter()
+            .any(|e| e.name == "CALIBAN_PROVIDER" && e.value.as_deref() == Some("ollama")));
+        assert!(env
+            .iter()
+            .any(|e| e.name == "FOO" && e.value.as_deref() == Some("bar")));
+    }
+
+    #[test]
     fn plan_names_all_three_children() {
-        let p = plan(&task(), &Settings::default());
+        let p = plan(&task(), &resolved(), &Settings::default());
         assert_eq!(
             p.service_account.metadata.name.as_deref(),
             Some("refactor-auth-sa")

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -5,8 +5,8 @@
 use std::collections::BTreeMap;
 
 use k8s_openapi::api::core::v1::{
-    Container, ContainerPort, EnvVar, PersistentVolumeClaimSpec, PodSpec, PodTemplateSpec,
-    ServiceAccount, VolumeMount, VolumeResourceRequirements,
+    Container, ContainerPort, EnvVar, EnvVarSource, PersistentVolumeClaimSpec, PodSpec,
+    PodTemplateSpec, SecretKeySelector, ServiceAccount, VolumeMount, VolumeResourceRequirements,
 };
 use k8s_openapi::api::networking::v1::{
     NetworkPolicy, NetworkPolicyEgressRule, NetworkPolicyIngressRule, NetworkPolicyPeer,
@@ -20,6 +20,7 @@ use kube::ResourceExt;
 use crate::config::{common_labels, netpol_name, owner_ref, sa_name, sandbox_name, Settings};
 use crate::crd::CalibanTask;
 use crate::sandbox::{Sandbox, SandboxSpec, VolumeClaimTemplate};
+use crate::workspace::ResolvedProvider;
 
 fn child_meta(t: &CalibanTask, name: String, labels: BTreeMap<String, String>) -> ObjectMeta {
     ObjectMeta {
@@ -106,6 +107,34 @@ fn caliband_env(t: &CalibanTask) -> Vec<EnvVar> {
         .and_then(|m| m.router_config_ref.clone())
     {
         e.push(env("CALIBAN_ROUTER_CONFIG_REF", r));
+    }
+    e
+}
+
+/// Project a resolved provider to caliband container env. Credentials reach the
+/// pod via `secretKeyRef` (the operator never inlines the value).
+#[allow(dead_code)]
+pub(crate) fn provider_env(rp: &ResolvedProvider) -> Vec<EnvVar> {
+    let mut e = vec![env("CALIBAN_PROVIDER", rp.kind.clone())];
+    if let Some(u) = &rp.base_url {
+        e.push(env("CALIBAN_PROVIDER_BASE_URL", u.clone()));
+    }
+    if let Some(m) = &rp.model {
+        e.push(env("CALIBAN_MODEL", m.clone()));
+    }
+    if let Some(c) = &rp.credentials_ref {
+        e.push(EnvVar {
+            name: "CALIBAN_API_KEY".to_string(),
+            value: None,
+            value_from: Some(EnvVarSource {
+                secret_key_ref: Some(SecretKeySelector {
+                    name: c.secret_name.clone(),
+                    key: c.key.clone(),
+                    optional: Some(false),
+                }),
+                ..Default::default()
+            }),
+        });
     }
     e
 }
@@ -478,6 +507,64 @@ mod tests {
         assert_eq!(
             p.sandbox.metadata.name.as_deref(),
             Some("refactor-auth-sbx")
+        );
+    }
+
+    #[test]
+    fn provider_env_projects_kind_url_model_and_secret_ref() {
+        use crate::workspace::{CredentialsRef, ResolvedProvider};
+        let rp = ResolvedProvider {
+            name: "planner".into(),
+            kind: "anthropic".into(),
+            base_url: Some("https://api.anthropic.com".into()),
+            model: Some("claude-opus-4-8".into()),
+            credentials_ref: Some(CredentialsRef {
+                secret_name: "anthropic-key".into(),
+                key: "api-key".into(),
+            }),
+        };
+        let env = provider_env(&rp);
+        let get = |n: &str| env.iter().find(|e| e.name == n).cloned();
+        assert_eq!(
+            get("CALIBAN_PROVIDER").unwrap().value.as_deref(),
+            Some("anthropic")
+        );
+        assert_eq!(
+            get("CALIBAN_PROVIDER_BASE_URL").unwrap().value.as_deref(),
+            Some("https://api.anthropic.com")
+        );
+        assert_eq!(
+            get("CALIBAN_MODEL").unwrap().value.as_deref(),
+            Some("claude-opus-4-8")
+        );
+        // Secret reaches the pod by reference, never inlined.
+        let key = get("CALIBAN_API_KEY").unwrap();
+        assert!(key.value.is_none());
+        let sel = key.value_from.unwrap().secret_key_ref.unwrap();
+        assert_eq!(sel.name, "anthropic-key");
+        assert_eq!(sel.key, "api-key");
+    }
+
+    #[test]
+    fn provider_env_keyless_has_no_api_key() {
+        use crate::workspace::ResolvedProvider;
+        let rp = ResolvedProvider {
+            name: "workers".into(),
+            kind: "ollama".into(),
+            base_url: Some("http://192.168.1.240:11434".into()),
+            model: None,
+            credentials_ref: None,
+        };
+        let env = provider_env(&rp);
+        assert!(!env.iter().any(|e| e.name == "CALIBAN_API_KEY"));
+        assert!(!env.iter().any(|e| e.name == "CALIBAN_MODEL"));
+        assert_eq!(
+            env.iter()
+                .find(|e| e.name == "CALIBAN_PROVIDER")
+                .unwrap()
+                .value
+                .as_deref(),
+            Some("ollama")
         );
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,0 +1,201 @@
+//! The `Workspace` custom resource (v1alpha1): durable, shared config — sources,
+//! named providers (each with its own model + Secret reference), env, isolation —
+//! that `CalibanTask`s reference by name. Owned and reconciled by the operator,
+//! which is the sole reader of provider credential Secrets. See ADR 0004 and the
+//! Prospero K8s Config Plane design.
+
+use kube::CustomResource;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::crd::{Condition, IsolationSpec, Source};
+
+/// Desired state of a workspace: sources + named providers + defaults.
+#[derive(CustomResource, Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[kube(
+    group = "caliban.caliban-ai.dev",
+    version = "v1alpha1",
+    kind = "Workspace",
+    namespaced,
+    status = "WorkspaceStatus",
+    shortname = "cws",
+    printcolumn = r#"{"name":"Phase","type":"string","jsonPath":".status.phase"}"#,
+    printcolumn = r#"{"name":"Age","type":"date","jsonPath":".metadata.creationTimestamp"}"#
+)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceSpec {
+    /// Human-friendly dashboard label.
+    #[schemars(length(min = 1))]
+    pub display_name: String,
+    /// The workspace's git checkouts (1..N).
+    #[schemars(length(min = 1))]
+    pub sources: Vec<Source>,
+    /// Named providers (1..N) agents in this workspace can bind to.
+    #[schemars(length(min = 1))]
+    pub providers: Vec<Provider>,
+    /// Provider name agents get when they don't request one. Implicit when
+    /// exactly one provider is defined.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_provider: Option<String>,
+    /// Non-secret environment injected into every agent pod.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<EnvEntry>,
+    /// Default isolation for agents launched against this workspace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isolation: Option<IsolationSpec>,
+}
+
+/// A named model provider bound within a workspace.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Provider {
+    /// Provider identifier, unique within the workspace (e.g. `planner`).
+    #[schemars(length(min = 1))]
+    pub name: String,
+    /// Provider kind (e.g. `ollama`, `anthropic`, `openai`).
+    #[schemars(length(min = 1))]
+    pub kind: String,
+    /// Override base URL (e.g. `http://192.168.1.240:11434`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+    /// Default model for this provider.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Reference to an existing Secret for this provider's API key. Keyless
+    /// providers (e.g. ollama) omit it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credentials_ref: Option<CredentialsRef>,
+}
+
+/// A by-name reference to a key within an existing Kubernetes Secret.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CredentialsRef {
+    /// Name of the Secret (same namespace).
+    #[schemars(length(min = 1))]
+    pub secret_name: String,
+    /// Key within the Secret's data.
+    #[schemars(length(min = 1))]
+    pub key: String,
+}
+
+/// A non-secret environment entry.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct EnvEntry {
+    /// Variable name.
+    #[schemars(length(min = 1))]
+    pub name: String,
+    /// Variable value.
+    pub value: String,
+}
+
+/// Observed state of a `Workspace`.
+#[derive(Serialize, Deserialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceStatus {
+    /// Lifecycle phase.
+    #[serde(default)]
+    pub phase: WorkspacePhase,
+    /// Standard Kubernetes conditions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub conditions: Vec<Condition>,
+    /// The `.metadata.generation` this status reflects.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub observed_generation: Option<i64>,
+    /// Human-readable detail (e.g. `provider 'planner': secret 'anthropic-key' not found`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+/// `Workspace` lifecycle phase.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq, JsonSchema)]
+pub enum WorkspacePhase {
+    /// Created, not yet reconciled.
+    #[default]
+    Pending,
+    /// Reconcile in progress.
+    Reconciling,
+    /// Valid — all providers and credential Secrets resolve.
+    Ready,
+    /// Invalid — see `message`.
+    Failed,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kube::CustomResourceExt;
+
+    #[test]
+    fn crd_has_correct_group_version_kind() {
+        let crd = Workspace::crd();
+        assert_eq!(crd.spec.group, "caliban.caliban-ai.dev");
+        assert_eq!(crd.spec.names.kind, "Workspace");
+        assert_eq!(crd.spec.versions[0].name, "v1alpha1");
+        assert_eq!(crd.spec.scope, "Namespaced");
+        assert!(crd.spec.versions[0]
+            .subresources
+            .as_ref()
+            .unwrap()
+            .status
+            .is_some());
+    }
+
+    #[test]
+    fn crd_enforces_non_empty_required_fields() {
+        let crd = Workspace::crd();
+        let schema = serde_json::to_value(&crd.spec.versions[0].schema).unwrap();
+        let spec = &schema["openAPIV3Schema"]["properties"]["spec"]["properties"];
+        assert_eq!(spec["sources"]["minItems"], 1);
+        assert_eq!(spec["providers"]["minItems"], 1);
+        assert_eq!(spec["displayName"]["minLength"], 1);
+        let prov = &spec["providers"]["items"]["properties"];
+        assert_eq!(prov["name"]["minLength"], 1);
+        assert_eq!(prov["kind"]["minLength"], 1);
+    }
+
+    #[test]
+    fn sample_cr_round_trips() {
+        let yaml = r#"
+apiVersion: caliban.caliban-ai.dev/v1alpha1
+kind: Workspace
+metadata: { name: team-a-ws, namespace: team-a }
+spec:
+  displayName: Team A
+  sources:
+    - { name: caliban, repo: "git@example:caliban", ref: main, path: /work/caliban }
+  providers:
+    - { name: planner, kind: anthropic, model: claude-opus-4-8, credentialsRef: { secretName: anthropic-key, key: api-key } }
+    - { name: workers, kind: ollama, baseUrl: "http://192.168.1.240:11434", model: qwen2.5-coder }
+  defaultProvider: planner
+"#;
+        let ws: Workspace = serde_norway::from_str(yaml).unwrap();
+        assert_eq!(ws.spec.providers.len(), 2);
+        assert_eq!(ws.spec.providers[0].name, "planner");
+        assert_eq!(
+            ws.spec.providers[0]
+                .credentials_ref
+                .as_ref()
+                .unwrap()
+                .secret_name,
+            "anthropic-key"
+        );
+        assert!(ws.spec.providers[1].credentials_ref.is_none());
+        assert_eq!(ws.spec.default_provider.as_deref(), Some("planner"));
+        // camelCase survives round-trip.
+        let v = serde_json::to_value(&ws.spec).unwrap();
+        assert!(v["displayName"].is_string());
+    }
+
+    #[test]
+    fn committed_crd_yaml_is_in_sync() {
+        let generated = serde_norway::to_string(&Workspace::crd()).unwrap();
+        let committed = include_str!("../deploy/crd/workspace.yaml");
+        assert_eq!(
+            generated.trim(),
+            committed.trim(),
+            "deploy/crd/workspace.yaml is stale — regenerate: cargo run --bin crdgen workspace > deploy/crd/workspace.yaml"
+        );
+    }
+}

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -122,10 +122,148 @@ pub enum WorkspacePhase {
     Failed,
 }
 
+/// Outcome of validating a `Workspace` against known Secret existence.
+pub struct WorkspaceValidation {
+    /// Derived phase (`Ready` or `Failed`).
+    pub phase: WorkspacePhase,
+    /// Human-readable failure detail, `None` when `Ready`.
+    pub message: Option<String>,
+}
+
+/// Pure validation of a `WorkspaceSpec`: unique provider names, a resolvable
+/// `defaultProvider`, and an existing Secret key for every `credentialsRef`.
+/// `secret_present(secret_name, key)` reports Secret-key existence (cluster
+/// lookup is the caller's responsibility). First problem found wins.
+pub fn validate_workspace(
+    spec: &WorkspaceSpec,
+    secret_present: impl Fn(&str, &str) -> bool,
+) -> WorkspaceValidation {
+    fn failed(message: String) -> WorkspaceValidation {
+        WorkspaceValidation {
+            phase: WorkspacePhase::Failed,
+            message: Some(message),
+        }
+    }
+
+    let mut seen = std::collections::BTreeSet::new();
+    for p in &spec.providers {
+        if !seen.insert(p.name.as_str()) {
+            return failed(format!("duplicate provider name '{}'", p.name));
+        }
+    }
+    if let Some(dp) = &spec.default_provider {
+        if !spec.providers.iter().any(|p| &p.name == dp) {
+            return failed(format!("defaultProvider '{dp}' names no provider"));
+        }
+    }
+    for p in &spec.providers {
+        if let Some(c) = &p.credentials_ref {
+            if !secret_present(&c.secret_name, &c.key) {
+                return failed(format!(
+                    "provider '{}': secret '{}' key '{}' not found",
+                    p.name, c.secret_name, c.key
+                ));
+            }
+        }
+    }
+    WorkspaceValidation {
+        phase: WorkspacePhase::Ready,
+        message: None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use kube::CustomResourceExt;
+
+    fn spec_with(providers: Vec<Provider>, default_provider: Option<&str>) -> WorkspaceSpec {
+        WorkspaceSpec {
+            display_name: "Team A".into(),
+            sources: vec![Source {
+                name: "caliban".into(),
+                repo: "git@x:caliban".into(),
+                r#ref: "main".into(),
+                path: "/work/caliban".into(),
+            }],
+            providers,
+            default_provider: default_provider.map(String::from),
+            env: vec![],
+            isolation: None,
+        }
+    }
+
+    fn provider(name: &str, cred: Option<(&str, &str)>) -> Provider {
+        Provider {
+            name: name.into(),
+            kind: "anthropic".into(),
+            base_url: None,
+            model: None,
+            credentials_ref: cred.map(|(s, k)| CredentialsRef {
+                secret_name: s.into(),
+                key: k.into(),
+            }),
+        }
+    }
+
+    #[test]
+    fn valid_workspace_is_ready() {
+        let spec = spec_with(
+            vec![provider("planner", Some(("anthropic-key", "api-key")))],
+            Some("planner"),
+        );
+        let v = validate_workspace(&spec, |s, k| s == "anthropic-key" && k == "api-key");
+        assert_eq!(v.phase, WorkspacePhase::Ready);
+        assert!(v.message.is_none());
+    }
+
+    #[test]
+    fn keyless_provider_needs_no_secret() {
+        let mut p = provider("workers", None);
+        p.kind = "ollama".into();
+        let spec = spec_with(vec![p], None);
+        let v = validate_workspace(&spec, |_, _| false); // no secrets exist at all
+        assert_eq!(v.phase, WorkspacePhase::Ready);
+    }
+
+    #[test]
+    fn missing_secret_fails_with_message() {
+        let spec = spec_with(
+            vec![provider("planner", Some(("anthropic-key", "api-key")))],
+            None,
+        );
+        let v = validate_workspace(&spec, |_, _| false);
+        assert_eq!(v.phase, WorkspacePhase::Failed);
+        assert_eq!(
+            v.message.as_deref(),
+            Some("provider 'planner': secret 'anthropic-key' key 'api-key' not found")
+        );
+    }
+
+    #[test]
+    fn duplicate_provider_names_fail() {
+        let spec = spec_with(
+            vec![provider("planner", None), provider("planner", None)],
+            None,
+        );
+        let v = validate_workspace(&spec, |_, _| true);
+        assert_eq!(v.phase, WorkspacePhase::Failed);
+        assert_eq!(
+            v.message.as_deref(),
+            Some("duplicate provider name 'planner'")
+        );
+    }
+
+    #[test]
+    fn dangling_default_provider_fails() {
+        let spec = spec_with(vec![provider("planner", None)], Some("nope"));
+        let v = validate_workspace(&spec, |_, _| true);
+        assert_eq!(v.phase, WorkspacePhase::Failed);
+        assert_eq!(
+            v.message.as_deref(),
+            Some("defaultProvider 'nope' names no provider")
+        );
+    }
 
     #[test]
     fn crd_has_correct_group_version_kind() {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -172,6 +172,85 @@ pub fn validate_workspace(
     }
 }
 
+/// A provider with its workspace context flattened in — the pinned form.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolvedProvider {
+    /// Provider name.
+    pub name: String,
+    /// Provider kind.
+    pub kind: String,
+    /// Base URL, if set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+    /// Model, if set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Credential Secret reference, if the provider needs one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credentials_ref: Option<CredentialsRef>,
+}
+
+/// The workspace config a `CalibanTask` runs against, resolved to a single
+/// provider and pinned into `CalibanTaskStatus.resolvedWorkspace` at admission.
+#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolvedWorkspace {
+    /// The workspace's source checkouts.
+    pub sources: Vec<Source>,
+    /// The single provider this task binds to.
+    pub provider: ResolvedProvider,
+    /// Non-secret env from the workspace.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<EnvEntry>,
+    /// Workspace default isolation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isolation: Option<IsolationSpec>,
+}
+
+/// Resolve a `WorkspaceSpec` + optional `providerRef` to a single-provider
+/// `ResolvedWorkspace`. Provider selection: explicit `provider_ref` →
+/// `defaultProvider` → the sole provider if there's exactly one. Errors on a
+/// dangling ref or an ambiguous choice.
+pub fn resolve_workspace(
+    spec: &WorkspaceSpec,
+    provider_ref: Option<&str>,
+) -> Result<ResolvedWorkspace, String> {
+    let chosen = match provider_ref {
+        Some(name) => spec
+            .providers
+            .iter()
+            .find(|p| p.name == name)
+            .ok_or_else(|| format!("providerRef '{name}' names no provider in the workspace"))?,
+        None => match &spec.default_provider {
+            Some(dp) => spec
+                .providers
+                .iter()
+                .find(|p| &p.name == dp)
+                .ok_or_else(|| format!("defaultProvider '{dp}' names no provider"))?,
+            None if spec.providers.len() == 1 => &spec.providers[0],
+            None => {
+                return Err(format!(
+                    "no providerRef and workspace has no defaultProvider among {} providers",
+                    spec.providers.len()
+                ))
+            }
+        },
+    };
+    Ok(ResolvedWorkspace {
+        sources: spec.sources.clone(),
+        provider: ResolvedProvider {
+            name: chosen.name.clone(),
+            kind: chosen.kind.clone(),
+            base_url: chosen.base_url.clone(),
+            model: chosen.model.clone(),
+            credentials_ref: chosen.credentials_ref.clone(),
+        },
+        env: spec.env.clone(),
+        isolation: spec.isolation.clone(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -335,5 +414,53 @@ spec:
             committed.trim(),
             "deploy/crd/workspace.yaml is stale — regenerate: cargo run --bin crdgen workspace > deploy/crd/workspace.yaml"
         );
+    }
+
+    #[test]
+    fn resolve_picks_named_provider() {
+        let spec = spec_with(
+            vec![
+                provider("planner", Some(("k", "v"))),
+                provider("workers", None),
+            ],
+            Some("planner"),
+        );
+        let r = resolve_workspace(&spec, Some("workers")).unwrap();
+        assert_eq!(r.provider.name, "workers");
+        assert_eq!(r.sources.len(), 1);
+    }
+
+    #[test]
+    fn resolve_falls_back_to_default_provider() {
+        let spec = spec_with(
+            vec![provider("planner", None), provider("workers", None)],
+            Some("workers"),
+        );
+        let r = resolve_workspace(&spec, None).unwrap();
+        assert_eq!(r.provider.name, "workers");
+    }
+
+    #[test]
+    fn resolve_uses_sole_provider_when_no_default() {
+        let spec = spec_with(vec![provider("only", None)], None);
+        let r = resolve_workspace(&spec, None).unwrap();
+        assert_eq!(r.provider.name, "only");
+    }
+
+    #[test]
+    fn resolve_ambiguous_without_default_errors() {
+        let spec = spec_with(vec![provider("a", None), provider("b", None)], None);
+        let err = resolve_workspace(&spec, None).unwrap_err();
+        assert_eq!(
+            err,
+            "no providerRef and workspace has no defaultProvider among 2 providers"
+        );
+    }
+
+    #[test]
+    fn resolve_dangling_provider_ref_errors() {
+        let spec = spec_with(vec![provider("planner", None)], None);
+        let err = resolve_workspace(&spec, Some("nope")).unwrap_err();
+        assert_eq!(err, "providerRef 'nope' names no provider in the workspace");
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -463,4 +463,18 @@ spec:
         let err = resolve_workspace(&spec, Some("nope")).unwrap_err();
         assert_eq!(err, "providerRef 'nope' names no provider in the workspace");
     }
+
+    #[test]
+    fn sample_manifests_deserialize() {
+        let ws: Workspace =
+            serde_norway::from_str(include_str!("../deploy/samples/workspace.yaml")).unwrap();
+        assert_eq!(ws.spec.providers.len(), 2);
+        let ct: crate::crd::CalibanTask =
+            serde_norway::from_str(include_str!("../deploy/samples/calibantask.yaml")).unwrap();
+        assert_eq!(ct.spec.workspace_ref.name, "team-a-ws");
+        assert_eq!(ct.spec.provider_ref.as_deref(), Some("workers"));
+        // The sample CalibanTask references a provider the sample Workspace defines.
+        let r = resolve_workspace(&ws.spec, ct.spec.provider_ref.as_deref()).unwrap();
+        assert_eq!(r.provider.kind, "ollama");
+    }
 }

--- a/src/workspace_controller.rs
+++ b/src/workspace_controller.rs
@@ -1,0 +1,1 @@
+//! placeholder

--- a/src/workspace_controller.rs
+++ b/src/workspace_controller.rs
@@ -1,1 +1,163 @@
-//! placeholder
+//! The `Workspace` controller: validates each `Workspace` (the operator is the
+//! sole Secret reader) and writes `status.phase` / `message` /
+//! `observedGeneration`. Provisions nothing. See ADR 0004.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::StreamExt as _;
+use k8s_openapi::api::core::v1::Secret;
+use kube::api::{Patch, PatchParams};
+use kube::runtime::controller::Action;
+use kube::runtime::watcher::Config;
+use kube::runtime::Controller;
+use kube::{Api, Client, ResourceExt};
+
+use crate::workspace::{validate_workspace, Workspace, WorkspaceStatus, WorkspaceValidation};
+
+/// Controller error.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// Kubernetes API error.
+    #[error("kube api: {0}")]
+    Kube(#[from] kube::Error),
+    /// Status serialization error.
+    #[error("serialize status: {0}")]
+    Serialize(#[from] serde_json::Error),
+}
+
+/// Derive the new `WorkspaceStatus` from a validation result. Returns `Some`
+/// only when it differs from the observed status (no-op-churn avoidance,
+/// mirroring `controller::derive_status`).
+pub(crate) fn derive_workspace_status(
+    ws: &Workspace,
+    v: WorkspaceValidation,
+) -> Option<WorkspaceStatus> {
+    let mut next = ws.status.clone().unwrap_or_default();
+    next.phase = v.phase;
+    next.message = v.message;
+    next.observed_generation = ws.metadata.generation;
+    match &ws.status {
+        Some(cur)
+            if cur.phase == next.phase
+                && cur.message == next.message
+                && cur.observed_generation == next.observed_generation =>
+        {
+            None
+        }
+        _ => Some(next),
+    }
+}
+
+async fn reconcile(ws: Arc<Workspace>, ctx: Arc<Client>) -> Result<Action, Error> {
+    let ns = ws.namespace().unwrap_or_default();
+    let name = ws.name_any();
+    let secrets: Api<Secret> = Api::namespaced((*ctx).clone(), &ns);
+
+    // Resolve which (secretName, key) pairs actually exist, once, up front, so
+    // validate_workspace stays pure.
+    let mut present: std::collections::BTreeSet<(String, String)> = Default::default();
+    for p in &ws.spec.providers {
+        if let Some(c) = &p.credentials_ref {
+            if let Some(sec) = secrets.get_opt(&c.secret_name).await? {
+                let has = sec.data.as_ref().is_some_and(|d| d.contains_key(&c.key))
+                    || sec
+                        .string_data
+                        .as_ref()
+                        .is_some_and(|d| d.contains_key(&c.key));
+                if has {
+                    present.insert((c.secret_name.clone(), c.key.clone()));
+                }
+            }
+        }
+    }
+    let validation = validate_workspace(&ws.spec, |s, k| {
+        present.contains(&(s.to_string(), k.to_string()))
+    });
+
+    if let Some(status) = derive_workspace_status(&ws, validation) {
+        let api: Api<Workspace> = Api::namespaced((*ctx).clone(), &ns);
+        let phase = status.phase;
+        let patch = serde_json::json!({ "status": status });
+        api.patch_status(&name, &PatchParams::default(), &Patch::Merge(&patch))
+            .await?;
+        tracing::info!(%ns, %name, ?phase, "patched Workspace status");
+    }
+    Ok(Action::requeue(Duration::from_secs(300)))
+}
+
+fn error_policy(_ws: Arc<Workspace>, err: &Error, _ctx: Arc<Client>) -> Action {
+    tracing::warn!(error = %err, "workspace reconcile error");
+    Action::requeue(Duration::from_secs(30))
+}
+
+/// Run the Workspace controller until shutdown.
+pub async fn run(client: Client) -> anyhow::Result<()> {
+    let workspaces: Api<Workspace> = Api::all(client.clone());
+    let ctx = Arc::new(client);
+    Controller::new(workspaces, Config::default())
+        .shutdown_on_signal()
+        .run(reconcile, error_policy, ctx)
+        .for_each(|res| async move {
+            match res {
+                Ok((obj, _)) => tracing::debug!(?obj, "workspace reconciled"),
+                Err(e) => tracing::warn!(error = %e, "workspace controller error"),
+            }
+        })
+        .await;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crd::Source;
+    use crate::workspace::{Provider, WorkspacePhase, WorkspaceSpec};
+
+    fn workspace(gen: i64) -> Workspace {
+        let mut ws = Workspace::new(
+            "team-a-ws",
+            WorkspaceSpec {
+                display_name: "Team A".into(),
+                sources: vec![Source {
+                    name: "caliban".into(),
+                    repo: "git@x:caliban".into(),
+                    r#ref: "main".into(),
+                    path: "/work/caliban".into(),
+                }],
+                providers: vec![Provider {
+                    name: "workers".into(),
+                    kind: "ollama".into(),
+                    base_url: None,
+                    model: None,
+                    credentials_ref: None,
+                }],
+                default_provider: None,
+                env: vec![],
+                isolation: None,
+            },
+        );
+        ws.metadata.namespace = Some("team-a".into());
+        ws.metadata.generation = Some(gen);
+        ws
+    }
+
+    #[test]
+    fn ready_status_is_derived_and_records_generation() {
+        let ws = workspace(3);
+        let v = validate_workspace(&ws.spec, |_, _| true);
+        let s = derive_workspace_status(&ws, v).unwrap();
+        assert_eq!(s.phase, WorkspacePhase::Ready);
+        assert_eq!(s.observed_generation, Some(3));
+        assert!(s.message.is_none());
+    }
+
+    #[test]
+    fn unchanged_status_is_noop() {
+        let mut ws = workspace(3);
+        let v = validate_workspace(&ws.spec, |_, _| true);
+        ws.status = derive_workspace_status(&ws, v);
+        let v2 = validate_workspace(&ws.spec, |_, _| true);
+        assert!(derive_workspace_status(&ws, v2).is_none());
+    }
+}


### PR DESCRIPTION
Change set **B** (operator foundation) of the Prospero K8s Config Plane epic. Closes #11.

Design of record: SilverBullet `Agent/Memory/Long-Term/References/Prospero-K8s-Config-Plane-Design`. ADR: `docs/adr/0004`.

## What

- **New `Workspace` CRD** (`caliban.caliban-ai.dev/v1alpha1`): durable, shared config — `sources[]`, a **named** `providers[]` list (each with its own `kind`/`baseUrl`/`model`/`credentialsRef`), `defaultProvider`, `env`, `isolation`. Plus a validation/status reconciler that confirms each `credentialsRef` Secret+key exists and writes `status.phase` (`Ready`/`Failed` with a human message). **The operator is the sole reader of Secrets.**
- **`CalibanTask` cutover (breaking, pre-v1)**: inline `spec.workspace` is **removed**, replaced by `workspaceRef` + optional `providerRef`. The reconciler resolves both **at admission**, pins the resolved config into `status.resolvedWorkspace` (immutable run — later `Workspace` edits don't mutate a running task), and **fails fast** with a clear condition on a dangling/unresolvable ref.
- **Provider credentials reach the pod via `secretKeyRef`** (`CALIBAN_API_KEY`) — never inlined into the CR or the operator's memory. Provider kind/baseUrl/model project as `CALIBAN_PROVIDER`/`CALIBAN_PROVIDER_BASE_URL`/`CALIBAN_MODEL`.
- Both CRD YAMLs generated + golden-tested; sample CRs (`deploy/samples/`) for the cross-repo contract test; ADR 0004.

## Breaking change

`CalibanTask.spec.workspace` is gone. Existing cluster CRs must be re-created under the new `workspaceRef` schema (accepted, pre-v1, no production deployment — ADR 0001/0004).

## Test

Full local gate green (mirrors CI): fmt, clippy `-D warnings`, build `--all-targets`, `cargo test` — **49 passing**. Pure-function coverage for `validate_workspace`, `resolve_workspace`, `provider_env`, `derive_status`/`derive_workspace_status`, plus golden CRD serialization and sample-CR consistency.

Built via subagent-driven development (implementer + reviewer per task, then a whole-branch review). The whole-branch review caught two status-hygiene bugs in the reconcile merge-patch logic (stale `Ready` condition on recovery; and empty-`conditions` being dropped by `skip_serializing_if` → churn) — both fixed with regression tests, mirroring the existing `caliband_endpoint`/`sandbox_ref` merge-delete pattern.

## Not in this PR (cross-repo / follow-up)

- Operator/prospero RBAC + CRD install → **helm-charts#30**; prospero editor + dashboard → **prospero#141** (both build against the frozen CRD contract here).
- Small deferred cleanups (logged for a follow-up ticket): pin not gated on `Workspace` readiness; unused `WorkspacePhase::Reconciling`; pre-existing orphaned `CalibanTaskStatus.workspace` field.

## Reality caveat

Reconcile/Secret paths are compile + pure-unit verified only (no envtest harness in-repo, per the design's CI caveat) — a live-cluster smoke is the real gate before production trust.