### PR TITLE
cleanup(crd): remove orphaned CalibanTaskStatus.workspace field (#15)

### DIFF
--- a/deploy/crd/calibantask.yaml
+++ b/deploy/crd/calibantask.yaml
@@ -287,17 +287,6 @@ spec:
                 required:
                 - name
                 type: object
-              workspace:
-                description: Observed workspace (incl. runtime-added sources).
-                nullable: true
-                properties:
-                  materialized:
-                    default: []
-                    description: Source names observed materialized in the pod.
-                    items:
-                      type: string
-                    type: array
-                type: object
             type: object
         required:
         - spec

--- a/src/crd.rs
+++ b/src/crd.rs
@@ -169,9 +169,6 @@ pub struct CalibanTaskStatus {
     /// Latest checkpoint reference.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub checkpoint_ref: Option<String>,
-    /// Observed workspace (incl. runtime-added sources).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub workspace: Option<WorkspaceStatus>,
     /// Standard Kubernetes conditions.
     // No `skip_serializing_if` here either (see `caliband_endpoint` above):
     // `derive_status` sets this to `[]` to clear a stale `Ready` condition
@@ -195,15 +192,6 @@ pub struct CalibanTaskStatus {
 pub struct NamedRef {
     /// Object name.
     pub name: String,
-}
-
-/// Observed workspace state.
-#[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct WorkspaceStatus {
-    /// Source names observed materialized in the pod.
-    #[serde(default)]
-    pub materialized: Vec<String>,
 }
 
 /// A minimal Kubernetes-style condition.


### PR DESCRIPTION
Follow-up from the #11 whole-branch review. Removes the dead `CalibanTaskStatus.workspace` field (never written by any controller) and its nested `WorkspaceStatus`/`materialized` types; regenerates `deploy/crd/calibantask.yaml`. Closes #15.

Gate green: fmt/clippy(-D warnings)/build/test — 49 passing.