### PR TITLE
cleanup(crd): remove dead WorkspacePhase::Reconciling variant (#14)

### DIFF
--- a/deploy/crd/workspace.yaml
+++ b/deploy/crd/workspace.yaml
@@ -188,7 +188,6 @@ spec:
                 description: Lifecycle phase.
                 enum:
                 - Pending
-                - Reconciling
                 - Ready
                 - Failed
                 type: string

--- a/docs/adr/0004-workspace-crd-and-resolve-and-pin.md
+++ b/docs/adr/0004-workspace-crd-and-resolve-and-pin.md
@@ -56,8 +56,9 @@ Forces:
    (the git checkouts), a **named** `providers` list (each `{name, kind, baseUrl,
    model, credentialsRef}` — a `credentialsRef` is a by-name Secret+key reference,
    never a value), an optional `defaultProvider`, non-secret `env`, and default
-   `isolation`. `WorkspaceStatus` carries `phase` (`Pending → Reconciling → Ready |
-   Failed`), `conditions`, `observedGeneration`, and a human-readable `message`. The
+   `isolation`. `WorkspaceStatus` carries `phase` (`Pending → Ready | Failed` —
+   validation is synchronous, so there is no observable intermediate reconciling
+   state), `conditions`, `observedGeneration`, and a human-readable `message`. The
    CRD YAML is generated from the Rust types and golden-tested in sync, per ADR
    0001's discipline.
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -114,8 +114,6 @@ pub enum WorkspacePhase {
     /// Created, not yet reconciled.
     #[default]
     Pending,
-    /// Reconcile in progress.
-    Reconciling,
     /// Valid — all providers and credential Secrets resolve.
     Ready,
     /// Invalid — see `message`.


### PR DESCRIPTION
Follow-up from the #11 whole-branch review. `WorkspacePhase::Reconciling` was never assigned (validation is synchronous → Ready/Failed only), so it was a dead variant and ADR 0004 overstated the lifecycle. Removes the variant, regenerates `workspace.yaml`, and corrects the ADR to `Pending → Ready | Failed`. Closes #14.

Gate green: 49 tests.