### PR TITLE
release: v0.2.0 — Workspace CRD + resolve-and-pin config plane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "caliban-operator"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "caliban-operator"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "AGPL-3.0-only"
-description = "Kubernetes operator (kube-rs) for caliban agent workloads (scaffolding — see caliban-ai/caliban#282)"
+description = "Kubernetes operator (kube-rs) reconciling caliban Workspace + CalibanTask CRs into sandboxed caliband workloads"
 repository = "https://github.com/caliban-ai/caliban-operator"
 publish = false
 


### PR DESCRIPTION
Bumps `caliban-operator` **0.1.1 → 0.2.0**. Minor bump: #11 is a breaking pre-v1 `CalibanTask` CRD change (`workspaceRef`/`providerRef` replaces inline `spec.workspace`) plus a new `Workspace` CRD.

Tagging the merge commit `v0.2.0` triggers `release-image.yml` to publish the multi-arch `ghcr.io/caliban-ai/caliban-operator:0.2.0` image — which **helm-charts#30** needs to wire the config plane into the charts (its L3 reconcile gate requires an operator image that understands the new schema).

### Rolled up since v0.1.1
- **feat(crd)**: `Workspace` CRD + `CalibanTask` resolve-and-pin; inline `spec.workspace` removed (breaking) — #11 (PR #12)
- **fix(operator)**: CRD schema validation, graceful shutdown, serde_yaml→serde_norway — #2 (PR #10)
- **fix(reconcile)**: gate CalibanTask pin on Workspace readiness — #13 (PR #18)
- **cleanup(crd)**: remove dead `WorkspacePhase::Reconciling` variant — #14 (PR #17)
- **cleanup(crd)**: remove orphaned `CalibanTaskStatus.workspace` field — #15 (PR #16)

Gate green locally: fmt/clippy(-D warnings)/build/test — 54 passing.