### PR TITLE
chore(crd): cluster-agnostic baseUrl example in the Workspace CRD

### DIFF
--- a/deploy/crd/workspace.yaml
+++ b/deploy/crd/workspace.yaml
@@ -74,7 +74,7 @@ spec:
                   description: A named model provider bound within a workspace.
                   properties:
                     baseUrl:
-                      description: Override base URL (e.g. `http://192.168.1.240:11434`).
+                      description: Override base URL (e.g. `http://ollama.example.com:11434`).
                       nullable: true
                       type: string
                     credentialsRef:

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -55,7 +55,7 @@ pub struct Provider {
     /// Provider kind (e.g. `ollama`, `anthropic`, `openai`).
     #[schemars(length(min = 1))]
     pub kind: String,
-    /// Override base URL (e.g. `http://192.168.1.240:11434`).
+    /// Override base URL (e.g. `http://ollama.example.com:11434`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
     /// Default model for this provider.
@@ -382,7 +382,7 @@ spec:
     - { name: caliban, repo: "git@example:caliban", ref: main, path: /work/caliban }
   providers:
     - { name: planner, kind: anthropic, model: claude-opus-4-8, credentialsRef: { secretName: anthropic-key, key: api-key } }
-    - { name: workers, kind: ollama, baseUrl: "http://192.168.1.240:11434", model: qwen2.5-coder }
+    - { name: workers, kind: ollama, baseUrl: "http://ollama.example.com:11434", model: qwen2.5-coder }
   defaultProvider: planner
 "#;
         let ws: Workspace = serde_norway::from_str(yaml).unwrap();


### PR DESCRIPTION
Follow-up to helm-charts#30. The `Provider.baseUrl` doc comment used an RFC1918 example IP (`192.168.1.240`) that leaks into the generated CRD description; helm-charts#30's leakage guard rejects that, so the chart neutralized it on copy. This aligns the source (`src/workspace.rs` + regenerated `deploy/crd/workspace.yaml`) to the same hostname (`ollama.example.com`) so the chart's CRD copy can be verbatim again.

Docs-only — no schema or behavior change, no new image needed. Gate green: fmt/clippy/build/test, 54 tests.