### PR TITLE
fix(sandbox): launch caliband with session-plane token + TLS (Bug 2)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,12 @@ pub struct Settings {
     pub workspace_storage: String,
     /// Container image for the git-clone init container that populates the workspace.
     pub git_image: String,
+    /// Name of the shared TLS serving-cert Secret (keys tls.crt/tls.key/ca.crt).
+    pub session_tls_secret: String,
+    /// Name of the shared bearer-token Secret.
+    pub session_token_secret: String,
+    /// Key within the token Secret.
+    pub session_token_key: String,
 }
 
 impl Default for Settings {
@@ -31,13 +37,17 @@ impl Default for Settings {
             workspace_root: "/work".to_string(),
             workspace_storage: "10Gi".to_string(),
             git_image: "alpine/git:latest".to_string(),
+            session_tls_secret: "caliban-session-plane-tls".to_string(),
+            session_token_secret: "caliban-session-plane-token".to_string(),
+            session_token_key: "token".to_string(),
         }
     }
 }
 
 impl Settings {
     /// Read settings from `CALIBAND_IMAGE`, `CALIBAND_PORT`, `CALIBAN_WORKSPACE_ROOT`,
-    /// `CALIBAN_WORKSPACE_STORAGE`, `CALIBAN_GIT_IMAGE`, falling back to defaults.
+    /// `CALIBAN_WORKSPACE_STORAGE`, `CALIBAN_GIT_IMAGE`, `CALIBAN_SESSION_TLS_SECRET`,
+    /// `CALIBAN_SESSION_TOKEN_SECRET`, `CALIBAN_SESSION_TOKEN_KEY`, falling back to defaults.
     pub fn from_env() -> Self {
         let d = Self::default();
         Self {
@@ -50,6 +60,12 @@ impl Settings {
             workspace_storage: std::env::var("CALIBAN_WORKSPACE_STORAGE")
                 .unwrap_or(d.workspace_storage),
             git_image: std::env::var("CALIBAN_GIT_IMAGE").unwrap_or(d.git_image),
+            session_tls_secret: std::env::var("CALIBAN_SESSION_TLS_SECRET")
+                .unwrap_or(d.session_tls_secret),
+            session_token_secret: std::env::var("CALIBAN_SESSION_TOKEN_SECRET")
+                .unwrap_or(d.session_token_secret),
+            session_token_key: std::env::var("CALIBAN_SESSION_TOKEN_KEY")
+                .unwrap_or(d.session_token_key),
         }
     }
 }
@@ -146,5 +162,13 @@ mod tests {
         assert_eq!(s.workspace_root, "/work");
         assert!(!s.git_image.contains("home"));
         assert!(!s.git_image.is_empty());
+    }
+
+    #[test]
+    fn session_plane_defaults_match_the_shared_secret_names() {
+        let s = Settings::default();
+        assert_eq!(s.session_tls_secret, "caliban-session-plane-tls");
+        assert_eq!(s.session_token_secret, "caliban-session-plane-token");
+        assert_eq!(s.session_token_key, "token");
     }
 }

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -658,6 +658,10 @@ mod tests {
             .unwrap();
         assert_eq!(sel.name, "caliban-session-plane-token");
         assert_eq!(sel.key, "token");
+        assert!(
+            tok.value.is_none(),
+            "token must never be inlined as plaintext"
+        );
 
         // TLS Secret mounted read-only at the expected path.
         let mount = c

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -6,7 +6,8 @@ use std::collections::BTreeMap;
 
 use k8s_openapi::api::core::v1::{
     Container, ContainerPort, EnvVar, EnvVarSource, PersistentVolumeClaimSpec, PodSpec,
-    PodTemplateSpec, SecretKeySelector, ServiceAccount, VolumeMount, VolumeResourceRequirements,
+    PodTemplateSpec, SecretKeySelector, SecretVolumeSource, ServiceAccount, Volume, VolumeMount,
+    VolumeResourceRequirements,
 };
 use k8s_openapi::api::networking::v1::{
     NetworkPolicy, NetworkPolicyEgressRule, NetworkPolicyIngressRule, NetworkPolicyPeer,
@@ -211,6 +212,9 @@ fn workspace_pvc(s: &Settings) -> VolumeClaimTemplate {
 /// Map a `CalibanTask` + its resolved workspace to the backing agent-sandbox
 /// `Sandbox`.
 pub fn build_sandbox(t: &CalibanTask, rw: &ResolvedWorkspace, s: &Settings) -> Sandbox {
+    const TLS_MOUNT: &str = "/etc/caliband/tls";
+    const TLS_VOLUME: &str = "session-tls";
+
     let labels = common_labels(t);
     let container = Container {
         name: "caliband".to_string(),
@@ -225,13 +229,40 @@ pub fn build_sandbox(t: &CalibanTask, rw: &ResolvedWorkspace, s: &Settings) -> S
             s.workspace_root.clone(),
             "--listen".to_string(),
             format!("0.0.0.0:{}", s.caliband_port),
+            "--tls-cert".to_string(),
+            format!("{TLS_MOUNT}/tls.crt"),
+            "--tls-key".to_string(),
+            format!("{TLS_MOUNT}/tls.key"),
         ]),
-        env: Some(caliband_env(t, rw)),
-        volume_mounts: Some(vec![VolumeMount {
-            name: WORKSPACE_VOLUME.to_string(),
-            mount_path: s.workspace_root.clone(),
-            ..Default::default()
-        }]),
+        env: Some({
+            let mut e = caliband_env(t, rw);
+            e.push(EnvVar {
+                name: "CALIBAN_DAEMON_TOKEN".to_string(),
+                value: None,
+                value_from: Some(EnvVarSource {
+                    secret_key_ref: Some(SecretKeySelector {
+                        name: s.session_token_secret.clone(),
+                        key: s.session_token_key.clone(),
+                        optional: Some(false),
+                    }),
+                    ..Default::default()
+                }),
+            });
+            e
+        }),
+        volume_mounts: Some(vec![
+            VolumeMount {
+                name: WORKSPACE_VOLUME.to_string(),
+                mount_path: s.workspace_root.clone(),
+                ..Default::default()
+            },
+            VolumeMount {
+                name: TLS_VOLUME.to_string(),
+                mount_path: TLS_MOUNT.to_string(),
+                read_only: Some(true),
+                ..Default::default()
+            },
+        ]),
         ..Default::default()
     };
     let pod_spec = PodSpec {
@@ -246,6 +277,14 @@ pub fn build_sandbox(t: &CalibanTask, rw: &ResolvedWorkspace, s: &Settings) -> S
             .or_else(|| rw.isolation.as_ref().and_then(|i| i.runtime_class.clone())),
         service_account_name: Some(sa_name(t)),
         automount_service_account_token: Some(false),
+        volumes: Some(vec![Volume {
+            name: TLS_VOLUME.to_string(),
+            secret: Some(SecretVolumeSource {
+                secret_name: Some(s.session_tls_secret.clone()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }]),
         ..Default::default()
     };
     let mut sb = Sandbox::new(
@@ -582,6 +621,64 @@ mod tests {
         assert!(env
             .iter()
             .any(|e| e.name == "FOO" && e.value.as_deref() == Some("bar")));
+    }
+
+    #[test]
+    fn sandbox_wires_session_plane_tls_and_token() {
+        let s = Settings::default();
+        let sb = build_sandbox(&task(), &resolved(), &s);
+        let pod = sb.spec.pod_template.spec.unwrap();
+        let c = &pod.containers[0];
+
+        // TLS args present and pointing at the mounted files.
+        let args = c.args.as_ref().unwrap();
+        let cert_idx = args
+            .iter()
+            .position(|a| a == "--tls-cert")
+            .expect("--tls-cert");
+        assert_eq!(args[cert_idx + 1], "/etc/caliband/tls/tls.crt");
+        let key_idx = args
+            .iter()
+            .position(|a| a == "--tls-key")
+            .expect("--tls-key");
+        assert_eq!(args[key_idx + 1], "/etc/caliband/tls/tls.key");
+
+        // Bearer token injected by reference (never inlined).
+        let env = c.env.as_ref().unwrap();
+        let tok = env
+            .iter()
+            .find(|e| e.name == "CALIBAN_DAEMON_TOKEN")
+            .expect("token env");
+        let sel = tok
+            .value_from
+            .as_ref()
+            .unwrap()
+            .secret_key_ref
+            .as_ref()
+            .unwrap();
+        assert_eq!(sel.name, "caliban-session-plane-token");
+        assert_eq!(sel.key, "token");
+
+        // TLS Secret mounted read-only at the expected path.
+        let mount = c
+            .volume_mounts
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|m| m.mount_path == "/etc/caliband/tls")
+            .expect("tls mount");
+        assert_eq!(mount.read_only, Some(true));
+        let vol = pod
+            .volumes
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|v| v.name == mount.name)
+            .expect("tls volume");
+        assert_eq!(
+            vol.secret.as_ref().unwrap().secret_name.as_deref(),
+            Some("caliban-session-plane-tls")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Bug 2 (operator half) — caliband pod crash-looped: `a non-empty bearer token is required`

caliband's `--listen` mode fail-closes unless launched with **both** a bearer token **and** TLS (`caliban` #400/#288). The operator's `build_sandbox` passed neither, so every agent pod exited with:

```
caliband: --listen: a non-empty bearer token is required for network (--listen) mode; refusing to bind an unauthenticated listener
```

### Fix
`build_sandbox` now launches caliband with the shared session-plane credentials:
- `--tls-cert /etc/caliband/tls/tls.crt --tls-key /etc/caliband/tls/tls.key` from a read-only mount of the TLS Secret;
- `CALIBAN_DAEMON_TOKEN` injected by `secretKeyRef` (never inlined as plaintext);
- `Settings` carries the Secret names (env-driven, defaulting to the shared contract names).

### Verification
fmt / clippy `-D warnings` / build / **56 tests** green. New test asserts the token is injected by reference only and never as a plaintext `value:`.

### Deploy coupling
Requires the shared Secrets provisioned by **helm-charts PR (same branch name)** — must deploy together, or the pod crash-loops on a missing Secret. That PR also gates the session plane behind cert-manager + `sessionPlane.enabled: true`.

Pairs with:
- helm-charts `fix/session-plane-credentials` (provisions + wires the Secrets)
- prospero #157 (Bug 1, independent)
