### PR TITLE
release: v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "caliban-operator"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "caliban-operator"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Kubernetes operator (kube-rs) reconciling caliban Workspace + CalibanTask CRs into sandboxed caliband workloads"


### PR DESCRIPTION
Minor release shipping the Bug 2 fix merged since v0.2.0:

- **#22** — `build_sandbox` launches caliband with the shared session-plane bearer token (`CALIBAN_DAEMON_TOKEN` via `secretKeyRef`) + TLS (`--tls-cert`/`--tls-key` from a mounted Secret), so the agent pod binds instead of crash-looping on `a non-empty bearer token is required`.

Bumps `version` 0.2.0 → 0.3.0 (new feature), regenerates `Cargo.lock`. Image-only release — tagging `v0.3.0` on the merge commit triggers `release-image.yml` to publish `ghcr.io/caliban-ai/caliban-operator:0.3.0`, needed for the live-cluster fix.

Local gate green (fmt / clippy `-D warnings` / build / test).