### PR TITLE
fix(sandbox,rbac): make k8s agent per-agent stream reachable (#24, #25)

### DIFF
--- a/docs/adr/0003-caliband-launch-contract.md
+++ b/docs/adr/0003-caliband-launch-contract.md
@@ -62,10 +62,12 @@ the caliban image's Dockerfile:
 - **The init container needs a git image and egress** to clone sources — the ADR 0002
   NetworkPolicy already allows general egress. Private sources will need credential
   projection (deferred).
-- **`advertise-host` / per-agent ports are not yet set.** Control-plane reachability
-  (`serviceFQDN:<port>`) works; per-agent attach dialing from outside the pod (prospero's
-  session plane) needs `--advertise-host <serviceFQDN>` + per-agent port routing — a
-  follow-up paired with prospero #77.
+- **`advertise-host` / per-agent ports** — _resolved (#24/#25)._ Control-plane
+  reachability (`serviceFQDN:<port>`) worked, but per-agent attach dialing from outside
+  the pod (prospero's session plane) needed `--advertise-host <serviceFQDN>` + per-agent
+  port routing. `build_sandbox` now passes `--advertise-host <sandbox>.<ns>.svc.cluster.local`
+  and pins `--agent-port-base`, and the NetworkPolicy opens the matching per-agent stream
+  window alongside the control port.
 - **`git clone --depth 1 --branch <ref>` accepts branch/tag names only, not commit
   SHAs** — a `ref` set to a raw commit SHA will fail the clone (the CRD's `ref` defaults
   to `main`; SHA-pinning is a follow-up).

--- a/docs/container.md
+++ b/docs/container.md
@@ -16,8 +16,9 @@ A two-stage build (`Dockerfile`):
 
 The image contains only the controller (`caliban-operator`), not the `crdgen`
 dev tool. Configuration is entirely via environment (`RUST_LOG`, `CALIBAND_IMAGE`,
-`CALIBAND_PORT`, `CALIBAN_WORKSPACE_ROOT`, `CALIBAN_WORKSPACE_STORAGE`,
-`CALIBAN_GIT_IMAGE`) — see the `caliban-operator` Helm chart.
+`CALIBAND_PORT`, `CALIBAN_AGENT_PORT_BASE`, `CALIBAN_AGENT_PORT_END`,
+`CALIBAN_WORKSPACE_ROOT`, `CALIBAN_WORKSPACE_STORAGE`, `CALIBAN_GIT_IMAGE`)
+— see the `caliban-operator` Helm chart.
 
 ## Build locally
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,10 @@ pub struct Settings {
     pub caliband_image: String,
     /// TCP+TLS port caliband listens on inside the pod.
     pub caliband_port: i32,
+    /// Base port caliband draws per-agent stream listeners from (monotonic).
+    pub agent_port_base: i32,
+    /// Top of the per-agent stream port window the NetworkPolicy opens (inclusive).
+    pub agent_port_end: i32,
     /// Workspace root mount path in the pod.
     pub workspace_root: String,
     /// Requested size of the workspace PVC (e.g. `10Gi`).
@@ -34,6 +38,8 @@ impl Default for Settings {
         Self {
             caliband_image: "ghcr.io/caliban-ai/caliban:latest".to_string(),
             caliband_port: 8443,
+            agent_port_base: 7100,
+            agent_port_end: 7999,
             workspace_root: "/work".to_string(),
             workspace_storage: "10Gi".to_string(),
             git_image: "alpine/git:latest".to_string(),
@@ -45,9 +51,10 @@ impl Default for Settings {
 }
 
 impl Settings {
-    /// Read settings from `CALIBAND_IMAGE`, `CALIBAND_PORT`, `CALIBAN_WORKSPACE_ROOT`,
-    /// `CALIBAN_WORKSPACE_STORAGE`, `CALIBAN_GIT_IMAGE`, `CALIBAN_SESSION_TLS_SECRET`,
-    /// `CALIBAN_SESSION_TOKEN_SECRET`, `CALIBAN_SESSION_TOKEN_KEY`, falling back to defaults.
+    /// Read settings from `CALIBAND_IMAGE`, `CALIBAND_PORT`, `CALIBAN_AGENT_PORT_BASE`,
+    /// `CALIBAN_AGENT_PORT_END`, `CALIBAN_WORKSPACE_ROOT`, `CALIBAN_WORKSPACE_STORAGE`,
+    /// `CALIBAN_GIT_IMAGE`, `CALIBAN_SESSION_TLS_SECRET`, `CALIBAN_SESSION_TOKEN_SECRET`,
+    /// `CALIBAN_SESSION_TOKEN_KEY`, falling back to defaults.
     pub fn from_env() -> Self {
         let d = Self::default();
         Self {
@@ -56,6 +63,14 @@ impl Settings {
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(d.caliband_port),
+            agent_port_base: std::env::var("CALIBAN_AGENT_PORT_BASE")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(d.agent_port_base),
+            agent_port_end: std::env::var("CALIBAN_AGENT_PORT_END")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(d.agent_port_end),
             workspace_root: std::env::var("CALIBAN_WORKSPACE_ROOT").unwrap_or(d.workspace_root),
             workspace_storage: std::env::var("CALIBAN_WORKSPACE_STORAGE")
                 .unwrap_or(d.workspace_storage),
@@ -81,6 +96,17 @@ pub fn sa_name(t: &CalibanTask) -> String {
 /// Name of the task's NetworkPolicy.
 pub fn netpol_name(t: &CalibanTask) -> String {
     format!("{}-netpol", t.name_any())
+}
+
+/// In-cluster DNS caliband advertises for its per-agent stream endpoints: the
+/// Sandbox's headless service FQDN. caliband otherwise advertises its `0.0.0.0`
+/// bind address, which prosperod cannot reach (#24).
+pub fn caliband_advertise_host(t: &CalibanTask) -> String {
+    format!(
+        "{}.{}.svc.cluster.local",
+        sandbox_name(t),
+        t.namespace().unwrap_or_default()
+    )
 }
 
 /// Labels stamped on every child object, keyed to the owning task.
@@ -170,5 +196,25 @@ mod tests {
         assert_eq!(s.session_tls_secret, "caliban-session-plane-tls");
         assert_eq!(s.session_token_secret, "caliban-session-plane-token");
         assert_eq!(s.session_token_key, "token");
+    }
+
+    #[test]
+    fn agent_port_defaults_open_the_per_agent_window() {
+        let s = Settings::default();
+        // caliband draws per-agent stream ports monotonically from this base (#24/#25).
+        assert_eq!(s.agent_port_base, 7100);
+        // The NetworkPolicy opens [base, end]; 7999 leaves 900 spawns of headroom.
+        assert_eq!(s.agent_port_end, 7999);
+    }
+
+    #[test]
+    fn caliband_advertise_host_is_the_sandbox_service_fqdn() {
+        // The routable host prosperod dials for a per-agent stream: the Sandbox's
+        // in-cluster service DNS, not caliband's 0.0.0.0 bind address (#24).
+        let t = task();
+        assert_eq!(
+            caliband_advertise_host(&t),
+            "refactor-auth-sbx.team-a.svc.cluster.local"
+        );
     }
 }

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -18,7 +18,9 @@ use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
 use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 use kube::ResourceExt;
 
-use crate::config::{common_labels, netpol_name, owner_ref, sa_name, sandbox_name, Settings};
+use crate::config::{
+    caliband_advertise_host, common_labels, netpol_name, owner_ref, sa_name, sandbox_name, Settings,
+};
 use crate::crd::CalibanTask;
 use crate::sandbox::{Sandbox, SandboxSpec, VolumeClaimTemplate};
 use crate::workspace::{ResolvedProvider, ResolvedWorkspace};
@@ -50,6 +52,15 @@ fn np_port(proto: &str, port: i32) -> NetworkPolicyPort {
     }
 }
 
+/// A `[start, end]` inclusive port range (for caliband's per-agent stream window).
+fn np_port_range(proto: &str, start: i32, end: i32) -> NetworkPolicyPort {
+    NetworkPolicyPort {
+        protocol: Some(proto.to_string()),
+        port: Some(IntOrString::Int(start)),
+        end_port: Some(end),
+    }
+}
+
 /// Default-deny NetworkPolicy: allow DNS + general egress + caliband-port ingress.
 pub fn build_network_policy(t: &CalibanTask, s: &Settings) -> NetworkPolicy {
     NetworkPolicy {
@@ -61,9 +72,14 @@ pub fn build_network_policy(t: &CalibanTask, s: &Settings) -> NetworkPolicy {
                 ..Default::default()
             }),
             policy_types: Some(vec!["Ingress".to_string(), "Egress".to_string()]),
-            // Ingress: caliband port only.
+            // Ingress: the caliband control port plus the per-agent stream window
+            // prosperod dials once it resolves an agent's endpoint (#25). Without
+            // the range, the stream dial is blocked even with a routable host.
             ingress: Some(vec![NetworkPolicyIngressRule {
-                ports: Some(vec![np_port("TCP", s.caliband_port)]),
+                ports: Some(vec![
+                    np_port("TCP", s.caliband_port),
+                    np_port_range("TCP", s.agent_port_base, s.agent_port_end),
+                ]),
                 from: Some(vec![NetworkPolicyPeer {
                     pod_selector: Some(LabelSelector::default()),
                     ..Default::default()
@@ -229,6 +245,14 @@ pub fn build_sandbox(t: &CalibanTask, rw: &ResolvedWorkspace, s: &Settings) -> S
             s.workspace_root.clone(),
             "--listen".to_string(),
             format!("0.0.0.0:{}", s.caliband_port),
+            // Advertise the pod's routable DNS (not the 0.0.0.0 bind) so prosperod
+            // can reach the per-agent stream endpoints caliband hands out (#24).
+            "--advertise-host".to_string(),
+            caliband_advertise_host(t),
+            // Pin the per-agent port base so it stays locked to the window the
+            // NetworkPolicy opens (#25) — the operator is the single source of truth.
+            "--agent-port-base".to_string(),
+            s.agent_port_base.to_string(),
             "--tls-cert".to_string(),
             format!("{TLS_MOUNT}/tls.crt"),
             "--tls-key".to_string(),
@@ -419,6 +443,47 @@ mod tests {
             .match_labels
             .unwrap()
             .contains_key("caliban.caliban-ai.dev/task"));
+    }
+
+    #[test]
+    fn network_policy_opens_the_per_agent_stream_port_range() {
+        // #25: prosperod's per-agent stream dial targets a port drawn from the
+        // agent-port-base (7100) upward, which the old policy (8443-only) blocked.
+        let np = build_network_policy(&task(), &Settings::default());
+        let ingress = np.spec.unwrap().ingress.unwrap();
+        let ports = ingress[0].ports.clone().unwrap();
+        // The caliband control port is still allowed as a single port.
+        assert!(ports
+            .iter()
+            .any(|p| p.port == Some(IntOrString::Int(8443)) && p.end_port.is_none()));
+        // The per-agent stream window 7100..=7999 is allowed as a range.
+        assert!(ports
+            .iter()
+            .any(|p| p.port == Some(IntOrString::Int(7100)) && p.end_port == Some(7999)));
+    }
+
+    #[test]
+    fn sandbox_advertises_routable_host_and_pins_agent_port_base() {
+        let s = Settings::default();
+        let sb = build_sandbox(&task(), &resolved(), &s);
+        let pod = sb.spec.pod_template.spec.unwrap();
+        let args = pod.containers[0].args.as_ref().unwrap();
+        // #24: caliband advertises the pod's routable DNS for per-agent endpoints,
+        // not its 0.0.0.0 bind address.
+        let adv_idx = args
+            .iter()
+            .position(|a| a == "--advertise-host")
+            .expect("--advertise-host flag present");
+        assert_eq!(
+            args[adv_idx + 1],
+            "refactor-auth-sbx.team-a.svc.cluster.local"
+        );
+        // The operator pins the port base so it stays locked to the NetworkPolicy window.
+        let base_idx = args
+            .iter()
+            .position(|a| a == "--agent-port-base")
+            .expect("--agent-port-base flag present");
+        assert_eq!(args[base_idx + 1], "7100");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two companion fixes — **both required** before a k8s-fleet agent's output can stream to the dashboard. Under the k8s fleet, prospero spawns an agent in a pod's caliband and attaches to the **per-agent stream** endpoint caliband advertises. Two things broke that attach:

1. **#24 (`area/sandbox`)** — caliband advertised its per-agent endpoints using its `0.0.0.0` bind address, so prosperod dialed `tcp://0.0.0.0:<port>` (its own localhost) → `Connection refused`.
2. **#25 (`area/rbac`)** — the sandbox `NetworkPolicy` only opened the control port `8443`, so even a routable host would be blocked on the per-agent stream port.

## Changes

- **`build_sandbox`** — pass `--advertise-host <sandbox>.<ns>.svc.cluster.local` so the per-agent endpoints caliband hands out use the pod's routable DNS (the same host family the operator already writes into `status.calibandEndpoint`), and pin `--agent-port-base` so it stays locked to the NetworkPolicy window. (#24)
- **`build_network_policy`** — open the per-agent stream window `[agent_port_base, agent_port_end]` (default **7100–7999**, 900 spawns of headroom) as a port range alongside `8443`. (#25)
- **`Settings`** — add `agent_port_base` / `agent_port_end` (env `CALIBAN_AGENT_PORT_BASE` / `CALIBAN_AGENT_PORT_END`), the single source of truth feeding both the container arg and the ingress range so they can't drift.
- **Docs** — mark the ADR 0003 `advertise-host`/per-agent deferral resolved; list the new env vars in `docs/container.md`.

## Design decisions

- **One PR, not two** — the fixes are explicit companions; landing either alone leaves `main` in a non-streaming state.
- **Range window 7100–7999** — caliband's per-agent ports climb monotonically from the base with no reuse; a bounded window keeps least-privilege while giving generous headroom (configurable via env).
- **Operator pins `--agent-port-base`** — makes the operator authoritative for the base so the container arg and NetworkPolicy window are driven by one value.

## Testing

- New unit tests: NetworkPolicy opens the `7100..=7999` range alongside `8443`; sandbox args carry `--advertise-host` (routable FQDN) and `--agent-port-base`; Settings defaults + advertise-host helper.
- Full CI gate green locally: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo build --workspace --all-targets`, `cargo test --workspace` (60 passed).
- **Live e2e** (agent output streaming to the dashboard on the home cluster) is the reporter's acceptance step — it needs the running prospero/prosperod + cluster the issues were observed on.

Closes #24
Closes #25