### PR TITLE
release: v0.3.1 — per-agent stream reachability (#24, #25)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "caliban-operator"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "caliban-operator"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "AGPL-3.0-only"
 description = "Kubernetes operator (kube-rs) reconciling caliban Workspace + CalibanTask CRs into sandboxed caliband workloads"


### PR DESCRIPTION
## Release v0.3.1

Patch bump (bug fix). Rolls up the one PR merged since v0.3.0:

- **#26** — `fix(sandbox,rbac): make k8s agent per-agent stream reachable` (closes **#24**, **#25**). `build_sandbox` now advertises the pod's routable DNS (`--advertise-host <sandbox>.<ns>.svc.cluster.local`) and pins `--agent-port-base`; the sandbox NetworkPolicy opens the per-agent stream window (7100–7999) alongside the control port 8443. Together these let prosperod attach and stream a k8s agent's output to the dashboard instead of dialing `tcp://0.0.0.0:7100` (its own localhost).

**Image-only release** — tagging `v0.3.1` on the merge commit triggers `release-image.yml`, publishing `ghcr.io/caliban-ai/caliban-operator:0.3.1` (+ `:latest`, multi-arch). No CRD changes.

Version bumped in `Cargo.toml` + `Cargo.lock` (0.3.0 → 0.3.1). Full local gate green (fmt/clippy/build/test, 60 passing).